### PR TITLE
Use patient_id env variable in questionnaires

### DIFF
--- a/Dev/Filippo/MDD/BeckDepression.py
+++ b/Dev/Filippo/MDD/BeckDepression.py
@@ -4,6 +4,7 @@ import datetime
 import asyncio
 import sqlite3
 import uuid
+import os
 
 # Setup shared database
 conn = sqlite3.connect("patient_responses.db")
@@ -20,11 +21,13 @@ cursor.execute('''
 ''')
 conn.commit()
 
-# Generate patient ID
-patient_id = input("Enter patient identifier (or press Enter to generate one): ").strip()
+# Generate patient ID, preferring environment variable
+patient_id = os.environ.get("patient_id")
 if not patient_id:
-    patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
-    print(f"Generated Patient ID: {patient_id}")
+    patient_id = input("Enter patient identifier (or press Enter to generate one): ").strip()
+    if not patient_id:
+        patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
+        print(f"Generated Patient ID: {patient_id}")
 
 async def robot_say(text: str):
     print(f"[Ameca says]: {text}\n")

--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -5,12 +5,15 @@ import asyncio
 import datetime
 import sqlite3
 import uuid
+import os
 
-# Generate patient ID
-patient_id = input("Enter patient identifier (or press enter to generate one): ").strip()
+# Generate patient ID, preferring environment variable from main.py
+patient_id = os.environ.get("patient_id")
 if not patient_id:
-    patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
-    print(f"Generated Patient ID: {patient_id}")
+    patient_id = input("Enter patient identifier (or press enter to generate one): ").strip()
+    if not patient_id:
+        patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
+        print(f"Generated Patient ID: {patient_id}")
 
 # Setup shared database
 conn = sqlite3.connect("patient_responses.db")

--- a/Dev/Filippo/MDD/central_sensitization.py
+++ b/Dev/Filippo/MDD/central_sensitization.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import sqlite3
 import uuid
+import os
 
 # Initialize DB connection
 conn = sqlite3.connect("patient_responses.db")
@@ -33,11 +34,13 @@ cursor.execute('''
 ''')
 conn.commit()
 
-# Patient ID
-patient_id = input("Enter patient identifier (or press Enter to generate one): ").strip()
+# Patient ID – prefer environment variable from main.py
+patient_id = os.environ.get("patient_id")
 if not patient_id:
-    patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
-    print(f"Generated Patient ID: {patient_id}")
+    patient_id = input("Enter patient identifier (or press Enter to generate one): ").strip()
+    if not patient_id:
+        patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
+        print(f"Generated Patient ID: {patient_id}")
 
 def timestamp():
     return datetime.datetime.now().isoformat()

--- a/Dev/Filippo/MDD/dass21_assessment.py
+++ b/Dev/Filippo/MDD/dass21_assessment.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import sqlite3
 import uuid
+import os
 
 # SQLite setup
 conn = sqlite3.connect("patient_responses.db")
@@ -20,11 +21,13 @@ cursor.execute('''
 ''')
 conn.commit()
 
-# Patient ID setup
-patient_id = input("Enter patient identifier (or press Enter to auto-generate): ").strip()
+# Patient ID setup – use environment variable from main.py if available
+patient_id = os.environ.get("patient_id")
 if not patient_id:
-    patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
-    print(f"Generated Patient ID: {patient_id}")
+    patient_id = input("Enter patient identifier (or press Enter to auto-generate): ").strip()
+    if not patient_id:
+        patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
+        print(f"Generated Patient ID: {patient_id}")
 
 # Categories: d = depression, a = anxiety, s = stress
 questions = [

--- a/Dev/Filippo/MDD/eq5d5l_assessment.py
+++ b/Dev/Filippo/MDD/eq5d5l_assessment.py
@@ -3,6 +3,7 @@ import sqlite3
 import uuid
 import datetime
 import asyncio
+import os
 
 # Initialize DB
 conn = sqlite3.connect("patient_responses.db")
@@ -69,10 +70,12 @@ def get_timestamp():
     return datetime.datetime.now().isoformat()
 
 async def collect_patient_id():
-    pid = input("Enter patient ID (or press Enter to auto-generate): ").strip()
+    pid = os.environ.get("patient_id")
     if not pid:
-        pid = f"PAT-{uuid.uuid4().hex[:8]}"
-        print(f"[Info] Generated Patient ID: {pid}")
+        pid = input("Enter patient ID (or press Enter to auto-generate): ").strip()
+        if not pid:
+            pid = f"PAT-{uuid.uuid4().hex[:8]}"
+            print(f"[Info] Generated Patient ID: {pid}")
     return pid
 
 async def run_eq5d5l_questionnaire():

--- a/Dev/Filippo/MDD/oswestry_disability_index.py
+++ b/Dev/Filippo/MDD/oswestry_disability_index.py
@@ -1,6 +1,7 @@
 import sqlite3
 import uuid
 import datetime
+import os
 
 # Connect to or create database
 conn = sqlite3.connect("patient_responses.db")
@@ -20,10 +21,12 @@ cursor.execute('''
 conn.commit()
 
 # Generate patient ID or accept user-defined one
-patient_id = input("Enter patient identifier (or press enter to generate one): ").strip()
+patient_id = os.environ.get("patient_id")
 if not patient_id:
-    patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
-    print(f"Generated Patient ID: {patient_id}")
+    patient_id = input("Enter patient identifier (or press enter to generate one): ").strip()
+    if not patient_id:
+        patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
+        print(f"Generated Patient ID: {patient_id}")
 
 def get_timestamp():
     return datetime.datetime.now().isoformat()

--- a/Dev/Filippo/MDD/pain_catastrophizing.py
+++ b/Dev/Filippo/MDD/pain_catastrophizing.py
@@ -4,6 +4,7 @@ import sqlite3
 import datetime
 import uuid
 import asyncio
+import os
 
 # Initialize or connect to shared database
 conn = sqlite3.connect("patient_responses.db")
@@ -22,10 +23,12 @@ cursor.execute('''
 conn.commit()
 
 # Patient ID handling
-patient_id = input("Enter patient identifier (or press Enter to generate one): ").strip()
+patient_id = os.environ.get("patient_id")
 if not patient_id:
-    patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
-    print(f"Generated Patient ID: {patient_id}")
+    patient_id = input("Enter patient identifier (or press Enter to generate one): ").strip()
+    if not patient_id:
+        patient_id = f"PAT-{uuid.uuid4().hex[:8]}"
+        print(f"Generated Patient ID: {patient_id}")
 
 # PCS questions
 pcs_questions = [

--- a/Dev/Filippo/MDD/pittsburgh_sleep.py
+++ b/Dev/Filippo/MDD/pittsburgh_sleep.py
@@ -4,6 +4,7 @@ import datetime
 import sqlite3
 import uuid
 from typing import Literal
+import os
 
 # Initialize DB connection
 conn = sqlite3.connect("patient_responses.db")
@@ -31,10 +32,12 @@ def get_timestamp():
     return datetime.datetime.now().isoformat()
 
 def get_patient_id():
-    pid = input("Enter patient identifier (or press Enter to generate one): ").strip()
+    pid = os.environ.get("patient_id")
     if not pid:
-        pid = f"PAT-{uuid.uuid4().hex[:8]}"
-        print(f"Generated Patient ID: {pid}")
+        pid = input("Enter patient identifier (or press Enter to generate one): ").strip()
+        if not pid:
+            pid = f"PAT-{uuid.uuid4().hex[:8]}"
+            print(f"Generated Patient ID: {pid}")
     return pid
 
 # Map responses to scores as per PSQI guidance


### PR DESCRIPTION
## Summary
- check `os.environ['patient_id']` for ID before prompting in questionnaire scripts
- fall back to generating a new patient ID if not provided

## Testing
- `python -m py_compile Dev/Filippo/MDD/bpi_inventory.py Dev/Filippo/MDD/central_sensitization.py Dev/Filippo/MDD/dass21_assessment.py Dev/Filippo/MDD/eq5d5l_assessment.py Dev/Filippo/MDD/oswestry_disability_index.py Dev/Filippo/MDD/pain_catastrophizing.py Dev/Filippo/MDD/pittsburgh_sleep.py Dev/Filippo/MDD/BeckDepression.py`

------
https://chatgpt.com/codex/tasks/task_e_685f6ed53f9483279666f1d91671da76