### PR TITLE
Remove unused imports in MDD main script

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -1,7 +1,5 @@
 import asyncio
 import uuid
-import subprocess
-import datetime
 import sqlite3
 
 def generate_patient_id():


### PR DESCRIPTION
## Summary
- cleaned up `Dev/Filippo/MDD/main.py` by deleting unused `subprocess` and `datetime` imports

## Testing
- `pytest -q`
- `flake8 Dev/Filippo/MDD/main.py` *(fails: E302, E501)*

------
https://chatgpt.com/codex/tasks/task_e_685f700c5f4c832796ce22678bbb808e