### PR TITLE
Remove extra BDI table creation

### DIFF
--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -27,15 +27,6 @@ cursor.execute('''
         response TEXT
     )
 ''')
-cursor.execute('''
-    CREATE TABLE IF NOT EXISTS responses_bdi (
-        patient_id TEXT,
-        timestamp TEXT,
-        question_number INTEGER,
-        question_text TEXT,
-        score INTEGER
-    )
-''')
 conn.commit()
 
 # Long-form BPI Questions — simplified text w/ freeform or numeric entry


### PR DESCRIPTION
## Summary
- clean up BPI inventory by removing lines that create the `responses_bdi` table

## Testing
- `python -m py_compile Dev/Filippo/MDD/bpi_inventory.py`

------
https://chatgpt.com/codex/tasks/task_e_685f7010e5688327898fd22bba02d5eb