### PR TITLE
Use TTS for questionnaires

### DIFF
--- a/Dev/Filippo/MDD/BeckDepression.py
+++ b/Dev/Filippo/MDD/BeckDepression.py
@@ -30,7 +30,12 @@ if not patient_id:
         print(f"Generated Patient ID: {patient_id}")
 
 async def robot_say(text: str):
+    """Speak through TTS and print as fallback."""
     print(f"[Ameca says]: {text}\n")
+    try:
+        system.messaging.post("tts_say", [text, "eng"])
+    except Exception:
+        pass
 
 async def robot_listen() -> str:
     return input("Your response (0, 1, 2, 3): ").strip()
@@ -81,6 +86,7 @@ async def run_beck_depression_inventory():
             if response in ["0", "1", "2", "3"]:
                 score = int(response)
                 valid = True
+                await robot_say("Thank you.")
             else:
                 await robot_say("Please enter a valid response: 0, 1, 2, or 3.")
 

--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -29,6 +29,16 @@ cursor.execute('''
 ''')
 conn.commit()
 
+async def robot_say(text: str):
+    print(f"[Ameca]: {text}")
+    try:
+        system.messaging.post("tts_say", [text, "eng"])
+    except Exception:
+        pass
+
+async def robot_listen() -> str:
+    return input("Your response: ").strip()
+
 # Long-form BPI Questions — simplified text w/ freeform or numeric entry
 bpi_questions = [
     "1. Rate your pain at its worst in the last 24 hours (0 = No pain, 10 = Worst imaginable):",
@@ -60,8 +70,9 @@ bpi_questions = [
 # Auto-adjust question numbering (we split compound questions)
 async def run_bpi():
     for i, question in enumerate(bpi_questions):
-        print(f"\n{question}")
-        response = input("Your response: ").strip()
+        await robot_say(f"{question}")
+        response = await robot_listen()
+        await robot_say("Thank you.")
         timestamp = datetime.datetime.now().isoformat()
 
         cursor.execute('''
@@ -72,7 +83,7 @@ async def run_bpi():
 
         print(f"[Saved] Question {i + 1}: {response}")
 
-    print(f"\n✅ All responses saved for Patient ID: {patient_id}")
+    await robot_say(f"All responses saved for Patient ID: {patient_id}")
 
 if __name__ == "__main__":
     asyncio.run(run_bpi())

--- a/Dev/Filippo/MDD/central_sensitization.py
+++ b/Dev/Filippo/MDD/central_sensitization.py
@@ -47,6 +47,10 @@ def timestamp():
 
 async def robot_say(text):
     print(f"\n[Ameca]: {text}")
+    try:
+        system.messaging.post("tts_say", [text, "eng"])
+    except Exception:
+        pass
 
 async def robot_listen():
     return input("Your response: ").strip()
@@ -111,6 +115,7 @@ async def run_csi_inventory():
             ans = (await robot_listen()).lower()
             if ans in score_map:
                 score = score_map[ans]
+                await robot_say("Thank you.")
                 break
             await robot_say("Invalid answer. Please use: Never, Rarely, Sometimes, Often, Always")
 
@@ -138,6 +143,7 @@ async def run_csi_worksheet():
     for condition in csi_worksheet:
         await robot_say(f"Are you familiar with {condition}? (yes/no)")
         knows = (await robot_listen()).lower()
+        await robot_say("Thank you.")
         if knows == "no":
             await robot_say(f"Explaining {condition}...")
             await robot_say(f"{condition} is a health condition potentially related to chronic pain.")
@@ -146,9 +152,11 @@ async def run_csi_worksheet():
         else:
             await robot_say(f"Have you been diagnosed with {condition}? (yes/no)")
             diagnosed = (await robot_listen()).lower()
+            await robot_say("Thank you.")
             if diagnosed == "yes":
                 await robot_say("In what year were you diagnosed?")
                 year = await robot_listen()
+                await robot_say("Thank you.")
             else:
                 year = "N/A"
 

--- a/Dev/Filippo/MDD/dass21_assessment.py
+++ b/Dev/Filippo/MDD/dass21_assessment.py
@@ -57,7 +57,12 @@ questions = [
 category_scores = {'d': 0, 'a': 0, 's': 0}
 
 async def robot_say(text):
+    """Speak using TTS with console fallback."""
     print(f"\n[Ameca]: {text}")
+    try:
+        system.messaging.post("tts_say", [text, "eng"])
+    except Exception:
+        pass
 
 async def robot_listen():
     return input("Your answer (0–3): ").strip()
@@ -92,6 +97,7 @@ async def run_dass21():
             if response in ['0', '1', '2', '3']:
                 score = int(response)
                 category_scores[category] += score
+                await robot_say("Thank you.")
                 break
             await robot_say("Invalid. Enter 0, 1, 2, or 3 only.")
 

--- a/Dev/Filippo/MDD/eq5d5l_assessment.py
+++ b/Dev/Filippo/MDD/eq5d5l_assessment.py
@@ -61,7 +61,12 @@ eq5d5l_dimensions = {
 }
 
 async def robot_say(msg: str):
+    """Speak via TTS with console fallback."""
     print(f"\n[Ameca]: {msg}")
+    try:
+        system.messaging.post("tts_say", [msg, "eng"])
+    except Exception:
+        pass
 
 async def robot_listen() -> str:
     return input("Your response: ").strip()
@@ -96,6 +101,7 @@ async def run_eq5d5l_questionnaire():
                 level = int(response)
                 levels.append(level)
                 health_state_code += str(level)
+                await robot_say("Thank you.")
                 cursor.execute('''
                     INSERT INTO responses_eq5d5l (patient_id, timestamp, dimension, level, health_state_code, vas_score)
                     VALUES (?, ?, ?, ?, ?, ?)
@@ -110,6 +116,7 @@ async def run_eq5d5l_questionnaire():
         vas_input = await robot_listen()
         if vas_input.isdigit() and 0 <= int(vas_input) <= 100:
             vas_score = int(vas_input)
+            await robot_say("Thank you.")
             break
         else:
             await robot_say("Enter a valid number between 0 and 100.")

--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -2,6 +2,15 @@ import asyncio
 import uuid
 import sqlite3
 
+import BeckDepression
+import bpi_inventory
+import central_sensitization
+import dass21_assessment
+import eq5d5l_assessment
+import oswestry_disability_index
+import pain_catastrophizing
+import pittsburgh_sleep
+
 def generate_patient_id():
     return f"PAT-{uuid.uuid4().hex[:8]}"
 
@@ -98,28 +107,24 @@ def store_demographics(patient_id, data):
     conn.commit()
     conn.close()
 
-async def run_script(script_name, patient_id):
-    print(f"\n🟢 Running: {script_name}...")
-    process = await asyncio.create_subprocess_exec(
-        "python", script_name,
-        env={**dict(patient_id=patient_id)},
-    )
-    await process.wait()
+async def run_all_assessments(patient_id: str):
+    """Run all questionnaires sequentially."""
+    import os
+    os.environ["patient_id"] = patient_id
+
+    await bpi_inventory.run_bpi()
+    await central_sensitization.run_csi_inventory()
+    await central_sensitization.run_csi_worksheet()
+    await dass21_assessment.run_dass21()
+    await eq5d5l_assessment.run_eq5d5l_questionnaire()
+    await oswestry_disability_index.run_odi()
+    await pain_catastrophizing.run_pcs()
+    await pittsburgh_sleep.run_psqi()
+    await BeckDepression.run_beck_depression_inventory()
 
 async def main():
     patient_id = collect_demographics()
-    scripts = [
-        "bpi_inventory.py",
-        "central_sensitization.py",
-        "dass21_assessment.py",
-        "eq5d5l_assessment.py",
-        "oswestry_disability_index.py",
-        "pain_catastrophizing.py",
-        "pittsburgh_sleep.py",
-        "BeckDepression.py"  # Last
-    ]
-    for script in scripts:
-        await run_script(script, patient_id)
+    await run_all_assessments(patient_id)
     print("\n✅ All assessments completed.")
 
 if __name__ == "__main__":

--- a/Dev/Filippo/MDD/pain_catastrophizing.py
+++ b/Dev/Filippo/MDD/pain_catastrophizing.py
@@ -60,6 +60,10 @@ def current_timestamp():
 
 async def robot_say(text):
     print(f"\n[Ameca]: {text}")
+    try:
+        system.messaging.post("tts_say", [text, "eng"])
+    except Exception:
+        pass
 
 async def robot_listen():
     return input("Your response (0-4): ").strip()
@@ -76,6 +80,7 @@ async def run_pcs():
             response = await robot_listen()
             if response in rating_scale:
                 score = int(response)
+                await robot_say("Thank you.")
                 break
             await robot_say("Invalid response. Please enter a number from 0 to 4.")
 

--- a/Dev/Filippo/MDD/pittsburgh_sleep.py
+++ b/Dev/Filippo/MDD/pittsburgh_sleep.py
@@ -24,6 +24,10 @@ conn.commit()
 
 async def robot_say(text):
     print(f"\n[Ameca]: {text}")
+    try:
+        system.messaging.post("tts_say", [text, "eng"])
+    except Exception:
+        pass
 
 async def robot_listen():
     return input("Your response: ").strip()
@@ -67,6 +71,7 @@ async def ask_and_store(patient_id, qnum, text, score_map=None):
     await robot_say(text)
     ans = (await robot_listen()).lower()
     score = score_map[ans] if score_map and ans in score_map else -1
+    await robot_say("Thank you.")
     cursor.execute(
         '''INSERT INTO responses_psqi VALUES (?, ?, ?, ?, ?, ?)''',
         (patient_id, get_timestamp(), qnum, text, ans.title(), score),

--- a/Dev/Filippo/MDD/questionnaire_actions.py
+++ b/Dev/Filippo/MDD/questionnaire_actions.py
@@ -1,0 +1,73 @@
+from typing import List
+
+ACTION_UTIL = system.import_library("../../../HB3/chat/actions/action_util.py")
+ActionRegistry = ACTION_UTIL.ActionRegistry
+ActionBuilder = ACTION_UTIL.ActionBuilder
+Action = ACTION_UTIL.Action
+
+bdi = system.import_library("./BeckDepression.py")
+dass = system.import_library("./dass21_assessment.py")
+eq5d = system.import_library("./eq5d5l_assessment.py")
+pcs = system.import_library("./pain_catastrophizing.py")
+psqi = system.import_library("./pittsburgh_sleep.py")
+csi = system.import_library("./central_sensitization.py")
+odi = system.import_library("./oswestry_disability_index.py")
+bpi = system.import_library("./bpi_inventory.py")
+
+
+@ActionRegistry.register_builder
+class RunQuestionnaires(ActionBuilder):
+    """Provide actions to run each MDD questionnaire."""
+
+    def factory(self) -> List[Action]:
+        async def run_beck_depression():
+            """Run the Beck Depression Inventory."""
+            await bdi.run_beck_depression_inventory()
+            return "beck_depression_finished"
+
+        async def run_dass21():
+            """Run the DASS-21 assessment."""
+            await dass.run_dass21()
+            return "dass21_finished"
+
+        async def run_eq5d5l():
+            """Run the EQ5D5L assessment."""
+            await eq5d.run_eq5d5l_questionnaire()
+            return "eq5d5l_finished"
+
+        async def run_pcs():
+            """Run the Pain Catastrophizing Scale."""
+            await pcs.run_pcs()
+            return "pcs_finished"
+
+        async def run_psqi():
+            """Run the Pittsburgh Sleep Quality Index."""
+            await psqi.run_psqi()
+            return "psqi_finished"
+
+        async def run_csi_inventory():
+            """Run the CSI inventory and worksheet."""
+            await csi.run_csi_inventory()
+            await csi.run_csi_worksheet()
+            return "csi_finished"
+
+        async def run_odi():
+            """Run the Oswestry Disability Index."""
+            await odi.run_odi()
+            return "odi_finished"
+
+        async def run_bpi():
+            """Run the Brief Pain Inventory."""
+            await bpi.run_bpi()
+            return "bpi_finished"
+
+        return [
+            run_bpi,
+            run_csi_inventory,
+            run_dass21,
+            run_eq5d5l,
+            run_odi,
+            run_pcs,
+            run_psqi,
+            run_beck_depression,
+        ]


### PR DESCRIPTION
## Summary
- add TTS output in all questionnaires
- respond "Thank you" after valid answers
- run all questionnaires directly from `main.py`
- expose questionnaire actions via `RunQuestionnaires` builder

## Testing
- `python -m py_compile Dev/Filippo/MDD/BeckDepression.py Dev/Filippo/MDD/dass21_assessment.py Dev/Filippo/MDD/eq5d5l_assessment.py Dev/Filippo/MDD/pain_catastrophizing.py Dev/Filippo/MDD/central_sensitization.py Dev/Filippo/MDD/pittsburgh_sleep.py Dev/Filippo/MDD/oswestry_disability_index.py Dev/Filippo/MDD/bpi_inventory.py Dev/Filippo/MDD/main.py Dev/Filippo/MDD/questionnaire_actions.py`

------
https://chatgpt.com/codex/tasks/task_e_685f72bfe3248327955310ff41e09b81