### PR TITLE
Add HTTP-based response storage

### DIFF
--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -3,7 +3,7 @@
 
 import asyncio
 import datetime
-import sqlite3
+from remote_storage import send_to_server
 import uuid
 import os
 
@@ -18,19 +18,7 @@ def get_patient_id() -> str:
             print(f"Generated Patient ID: {pid}")
     return pid
 
-# Setup shared database
-conn = sqlite3.connect("patient_responses.db")
-cursor = conn.cursor()
-cursor.execute('''
-    CREATE TABLE IF NOT EXISTS responses_bpi (
-        patient_id TEXT,
-        timestamp TEXT,
-        question_number INTEGER,
-        question_text TEXT,
-        response TEXT
-    )
-''')
-conn.commit()
+
 
 async def robot_say(text: str):
     print(f"[Ameca]: {text}")
@@ -79,11 +67,14 @@ async def run_bpi():
         await robot_say("Thank you.")
         timestamp = datetime.datetime.now().isoformat()
 
-        cursor.execute('''
-            INSERT INTO responses_bpi (patient_id, timestamp, question_number, question_text, response)
-            VALUES (?, ?, ?, ?, ?)
-        ''', (patient_id, timestamp, i + 1, question, response))
-        conn.commit()
+        send_to_server(
+            'responses_bpi',
+            patient_id=patient_id,
+            timestamp=timestamp,
+            question_number=i + 1,
+            question_text=question,
+            response=response,
+        )
 
         print(f"[Saved] Question {i + 1}: {response}")
 

--- a/Dev/Filippo/MDD/dass21_assessment.py
+++ b/Dev/Filippo/MDD/dass21_assessment.py
@@ -1,25 +1,11 @@
 # DASS-21 Questionnaire Script with Automatic Scoring and SQLite Storage
 import asyncio
 import datetime
-import sqlite3
+from remote_storage import send_to_server
 import uuid
 import os
 
-# SQLite setup
-conn = sqlite3.connect("patient_responses.db")
-cursor = conn.cursor()
 
-cursor.execute('''
-    CREATE TABLE IF NOT EXISTS responses_dass21 (
-        patient_id TEXT,
-        timestamp TEXT,
-        question_number INTEGER,
-        question_text TEXT,
-        score INTEGER,
-        category TEXT
-    )
-''')
-conn.commit()
 
 # Patient ID setup – use environment variable from main.py if available
 def get_patient_id() -> str:
@@ -104,10 +90,15 @@ async def run_dass21():
                 break
             await robot_say("Invalid. Enter 0, 1, 2, or 3 only.")
 
-        cursor.execute('''
-            INSERT INTO responses_dass21 VALUES (?, ?, ?, ?, ?, ?)
-        ''', (patient_id, datetime.datetime.now().isoformat(), number, text, score, category))
-        conn.commit()
+        send_to_server(
+            'responses_dass21',
+            patient_id=patient_id,
+            timestamp=datetime.datetime.now().isoformat(),
+            question_number=number,
+            question_text=text,
+            score=score,
+            category=category,
+        )
 
     await robot_say("Thank you. Here are your scores:")
     for cat, label in [('d', 'Depression'), ('a', 'Anxiety'), ('s', 'Stress')]:

--- a/Dev/Filippo/MDD/http_server.py
+++ b/Dev/Filippo/MDD/http_server.py
@@ -1,0 +1,138 @@
+from flask import Flask, request, jsonify
+import sqlite3
+
+DB_PATH = 'patient_responses.db'
+
+TABLE_SCHEMAS = {
+    'patient_demographics': '''
+        CREATE TABLE IF NOT EXISTS patient_demographics (
+            patient_id TEXT PRIMARY KEY,
+            date TEXT,
+            name_last TEXT,
+            name_first TEXT,
+            name_middle TEXT,
+            phone TEXT,
+            sex TEXT,
+            dob TEXT,
+            marital_status TEXT,
+            education TEXT,
+            degree TEXT,
+            occupation TEXT,
+            spouse_occupation TEXT,
+            job_status TEXT,
+            diagnosis_time TEXT,
+            disease_pain TEXT,
+            pain_symptom TEXT,
+            surgery TEXT,
+            surgery_type TEXT,
+            other_pain TEXT,
+            pain_med_week TEXT,
+            pain_med_daily TEXT
+        )''',
+    'responses_bdi': '''
+        CREATE TABLE IF NOT EXISTS responses_bdi (
+            patient_id TEXT,
+            timestamp TEXT,
+            question_number INTEGER,
+            question_title TEXT,
+            answer TEXT,
+            score INTEGER
+        )''',
+    'responses_bpi': '''
+        CREATE TABLE IF NOT EXISTS responses_bpi (
+            patient_id TEXT,
+            timestamp TEXT,
+            question_number INTEGER,
+            question_text TEXT,
+            response TEXT
+        )''',
+    'responses_csi': '''
+        CREATE TABLE IF NOT EXISTS responses_csi (
+            patient_id TEXT,
+            timestamp TEXT,
+            question_number INTEGER,
+            question_text TEXT,
+            answer TEXT,
+            score INTEGER
+        )''',
+    'worksheet_csi': '''
+        CREATE TABLE IF NOT EXISTS worksheet_csi (
+            patient_id TEXT,
+            timestamp TEXT,
+            condition TEXT,
+            knows_about TEXT,
+            diagnosed TEXT,
+            year_diagnosed TEXT
+        )''',
+    'responses_dass21': '''
+        CREATE TABLE IF NOT EXISTS responses_dass21 (
+            patient_id TEXT,
+            timestamp TEXT,
+            question_number INTEGER,
+            question_text TEXT,
+            score INTEGER,
+            category TEXT
+        )''',
+    'responses_eq5d5l': '''
+        CREATE TABLE IF NOT EXISTS responses_eq5d5l (
+            patient_id TEXT,
+            timestamp TEXT,
+            dimension TEXT,
+            level INTEGER,
+            health_state_code TEXT,
+            vas_score INTEGER
+        )''',
+    'responses_odi': '''
+        CREATE TABLE IF NOT EXISTS responses_odi (
+            patient_id TEXT,
+            timestamp TEXT,
+            question_number INTEGER,
+            question_text TEXT,
+            selected_option TEXT,
+            score INTEGER
+        )''',
+    'responses_pcs': '''
+        CREATE TABLE IF NOT EXISTS responses_pcs (
+            patient_id TEXT,
+            timestamp TEXT,
+            question_number INTEGER,
+            question_text TEXT,
+            score INTEGER
+        )''',
+    'responses_psqi': '''
+        CREATE TABLE IF NOT EXISTS responses_psqi (
+            patient_id TEXT,
+            timestamp TEXT,
+            question_number TEXT,
+            question_text TEXT,
+            answer TEXT,
+            score INTEGER
+        )'''
+}
+
+app = Flask(__name__)
+
+
+def get_conn():
+    return sqlite3.connect(DB_PATH)
+
+
+@app.route('/store', methods=['POST'])
+def store():
+    data = request.get_json(force=True)
+    table = data.pop('table', None)
+    if not table or table not in TABLE_SCHEMAS:
+        return jsonify({'error': 'unknown table'}), 400
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(TABLE_SCHEMAS[table])
+    columns = ', '.join(data.keys())
+    placeholders = ', '.join('?' for _ in data)
+    cur.execute(f"INSERT INTO {table} ({columns}) VALUES ({placeholders})", tuple(data.values()))
+    conn.commit()
+    conn.close()
+    return jsonify({'status': 'ok'})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -1,6 +1,6 @@
 import asyncio
 import uuid
-import sqlite3
+from remote_storage import send_to_server
 import datetime
 
 import BeckDepression
@@ -141,39 +141,11 @@ async def collect_demographics():
     return patient_id
 
 def store_demographics(patient_id, data):
-    conn = sqlite3.connect("patient_responses.db")
-    cursor = conn.cursor()
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS patient_demographics (
-            patient_id TEXT PRIMARY KEY,
-            date TEXT,
-            name_last TEXT,
-            name_first TEXT,
-            name_middle TEXT,
-            phone TEXT,
-            sex TEXT,
-            dob TEXT,
-            marital_status TEXT,
-            education TEXT,
-            degree TEXT,
-            occupation TEXT,
-            spouse_occupation TEXT,
-            job_status TEXT,
-            diagnosis_time TEXT,
-            disease_pain TEXT,
-            pain_symptom TEXT,
-            surgery TEXT,
-            surgery_type TEXT,
-            other_pain TEXT,
-            pain_med_week TEXT,
-            pain_med_daily TEXT
-        )
-    ''')
-    cursor.execute('''
-        INSERT OR REPLACE INTO patient_demographics VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ''', (patient_id, *data.values()))
-    conn.commit()
-    conn.close()
+    send_to_server(
+        'patient_demographics',
+        patient_id=patient_id,
+        **data,
+    )
 
 async def run_all_assessments(patient_id: str):
     """Run all questionnaires sequentially."""

--- a/Dev/Filippo/MDD/pain_catastrophizing.py
+++ b/Dev/Filippo/MDD/pain_catastrophizing.py
@@ -1,26 +1,12 @@
 # Pain Catastrophizing Scale (PCS) – Full Implementation with Scoring and DB Storage
 
-import sqlite3
+from remote_storage import send_to_server
 import datetime
 import uuid
 import asyncio
 import os
 
-# Initialize or connect to shared database
-conn = sqlite3.connect("patient_responses.db")
-cursor = conn.cursor()
 
-# Create table if it doesn't exist
-cursor.execute('''
-    CREATE TABLE IF NOT EXISTS responses_pcs (
-        patient_id TEXT,
-        timestamp TEXT,
-        question_number INTEGER,
-        question_text TEXT,
-        score INTEGER
-    )
-''')
-conn.commit()
 
 # Patient ID handling
 def get_patient_id() -> str:
@@ -88,11 +74,14 @@ async def run_pcs():
             await robot_say("Invalid response. Please enter a number from 0 to 4.")
 
         total_score += score
-        cursor.execute('''
-            INSERT INTO responses_pcs (patient_id, timestamp, question_number, question_text, score)
-            VALUES (?, ?, ?, ?, ?)
-        ''', (patient_id, current_timestamp(), i + 1, question, score))
-        conn.commit()
+        send_to_server(
+            'responses_pcs',
+            patient_id=patient_id,
+            timestamp=current_timestamp(),
+            question_number=i + 1,
+            question_text=question,
+            score=score,
+        )
 
         await robot_say(f"Recorded response: {rating_scale[response]} (Score: {score})")
 

--- a/Dev/Filippo/MDD/remote_storage.py
+++ b/Dev/Filippo/MDD/remote_storage.py
@@ -1,0 +1,13 @@
+import os
+import requests
+
+SERVER_URL = os.environ.get("SERVER_URL", "http://localhost:5000/store")
+
+
+def send_to_server(table: str, **data) -> None:
+    """Send a row of questionnaire data to the remote HTTP server."""
+    payload = {"table": table, **data}
+    try:
+        requests.post(SERVER_URL, json=payload, timeout=5)
+    except Exception as exc:
+        print(f"[WARN] Failed to send data to {SERVER_URL}: {exc}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests


### PR DESCRIPTION
## Summary
- remove sqlite usage from questionnaires
- add `remote_storage.py` helper using HTTP
- create Flask `http_server.py` to write to SQLite
- modify main demographics storage
- require Flask and requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f8060699883278ceb90341d9687f3