### PR TITLE
Simplify server implementation

### DIFF
--- a/Dev/Filippo/MDD/remote_storage.py
+++ b/Dev/Filippo/MDD/remote_storage.py
@@ -1,13 +1,17 @@
 import os
-import requests
+import json
+from urllib import request
 
 SERVER_URL = os.environ.get("SERVER_URL", "http://localhost:5000/store")
 
 
 def send_to_server(table: str, **data) -> None:
     """Send a row of questionnaire data to the remote HTTP server."""
-    payload = {"table": table, **data}
+    payload = json.dumps({"table": table, **data}).encode("utf-8")
+    req = request.Request(
+        SERVER_URL, data=payload, headers={"Content-Type": "application/json"}
+    )
     try:
-        requests.post(SERVER_URL, json=payload, timeout=5)
+        request.urlopen(req, timeout=5)
     except Exception as exc:
         print(f"[WARN] Failed to send data to {SERVER_URL}: {exc}")

--- a/Dev/Filippo/MDD/visualize_web.py
+++ b/Dev/Filippo/MDD/visualize_web.py
@@ -1,0 +1,125 @@
+import sqlite3
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from flask import Flask, render_template_string
+import base64
+import io
+
+DB_NAME = "patient_responses.db"
+
+app = Flask(__name__)
+
+def get_available_tables(conn):
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    return [row[0] for row in cur.fetchall() if row[0].startswith('responses_')]
+
+def get_all_patient_ids(conn, tables):
+    """Return all unique patient IDs across response tables."""
+    cur = conn.cursor()
+    selects = [f"SELECT patient_id FROM {t}" for t in tables]
+    union = " UNION ".join(selects)
+    cur.execute(f"SELECT DISTINCT patient_id FROM ({union}) AS all_ids")
+    return [str(row[0]) for row in cur.fetchall() if row[0] is not None]
+
+def plot_data_for_table(patient_id, conn, table_name):
+    """Create a bar chart for the given patient from the specified table."""
+    cols = [row[1] for row in conn.execute(f"PRAGMA table_info({table_name})")]
+    if 'score' not in cols:
+        return None  # skip tables without numeric scores
+
+    q_col = None
+    for possible in ('question_title', 'question_text', 'dimension'):
+        if possible in cols:
+            q_col = possible
+            break
+    if q_col is None:
+        return None
+
+    query = f"SELECT {q_col}, score FROM {table_name} WHERE patient_id = ?"
+    df = pd.read_sql_query(query, conn, params=(patient_id,))
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    if df.empty:
+        ax.text(0.5, 0.5, f'No data found for {table_name}', ha='center', va='center')
+        ax.axis('off')
+    else:
+        df[q_col] = df[q_col].astype(str).str[:40]
+        ax.bar(df[q_col], df['score'], color='#0d6efd')
+        ax.set_title(table_name.replace('responses_', '').upper())
+        ax.set_ylabel('Score')
+        ax.tick_params(axis='x', labelrotation=90)
+        ax.grid(True, axis='y', linestyle='--', alpha=0.7)
+
+    plt.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format='png')
+    plt.close(fig)
+    return base64.b64encode(buf.getvalue()).decode('utf-8')
+
+INDEX_TPL = """
+<!doctype html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"utf-8\">
+    <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
+    <title>Patient Dashboard</title>
+</head>
+<body class=\"bg-light\">
+<div class=\"container py-4\">
+  <h1 class=\"mb-4\">Patient Dashboard</h1>
+  <ul class=\"list-group\">
+  {% for pid in patient_ids %}
+    <li class=\"list-group-item\"><a href=\"/patient/{{ pid }}\">{{ pid }}</a></li>
+  {% endfor %}
+  </ul>
+</div>
+</body>
+</html>
+"""
+
+PATIENT_TPL = """
+<!doctype html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"utf-8\">
+    <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
+    <title>Results for {{ patient_id }}</title>
+</head>
+<body class=\"bg-light\">
+<div class=\"container py-4\">
+  <h1 class=\"mb-4\">Results for {{ patient_id }}</h1>
+  {% for table, img in images.items() if img %}
+    <div class=\"card mb-4\">
+      <div class=\"card-header\">{{ table.replace('responses_', '').upper() }}</div>
+      <div class=\"card-body text-center\">
+        <img class=\"img-fluid\" src=\"data:image/png;base64,{{ img }}\" alt=\"{{ table }}\">
+      </div>
+    </div>
+  {% endfor %}
+  <a class=\"btn btn-secondary\" href=\"/\">Back</a>
+</div>
+</body>
+</html>
+"""
+
+@app.route('/')
+def index():
+    conn = sqlite3.connect(DB_NAME)
+    tables = get_available_tables(conn)
+    patient_ids = get_all_patient_ids(conn, tables)
+    conn.close()
+    return render_template_string(INDEX_TPL, patient_ids=patient_ids)
+
+@app.route('/patient/<pid>')
+def patient(pid):
+    conn = sqlite3.connect(DB_NAME)
+    tables = get_available_tables(conn)
+    images = {table: plot_data_for_table(pid, conn, table) for table in tables}
+    conn.close()
+    return render_template_string(PATIENT_TPL, patient_id=pid, images=images)
+
+if __name__ == '__main__':
+    app.run(port=8000)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # MDD_Diagnosis
+
+## Running the HTTP server
+
+Patient questionnaire results can be stored remotely using
+`Dev/Filippo/MDD/http_server.py`.  The script uses only Python's built-in
+modules and writes incoming data to `patient_responses.db` in the current
+directory.
+
+```bash
+python Dev/Filippo/MDD/http_server.py
+```
+
+The server listens on port `5000` and automatically creates the database file if
+it does not already exist.
+
+## Configuring `SERVER_URL`
+
+Questionnaire modules send data to the URL specified by the `SERVER_URL`
+environment variable (default: `http://localhost:5000/store`).  Before running a
+client script, set this variable to point at the server location:
+
+```bash
+export SERVER_URL="http://<server-ip>:5000/store"
+```
+
+Replace `<server-ip>` with the address of the machine where `http_server.py` is
+running.
+
+## Verifying stored data
+
+After running the assessments, confirm that the responses were saved by querying
+`patient_responses.db`:
+
+```bash
+sqlite3 patient_responses.db ".tables"
+sqlite3 patient_responses.db "SELECT * FROM patient_demographics LIMIT 5;"
+```
+
+This will list the created tables such as `patient_demographics` and
+`responses_bdi`.  You can inspect table contents with standard SQLite commands
+to ensure that data was recorded.
+
+## Web dashboard
+
+You can view interactive charts of questionnaire results using a small Flask
+web dashboard.  The app reads from the same `patient_responses.db` database
+created by `http_server.py` and groups results by `patient_id`.
+
+```bash
+pip install flask pandas matplotlib
+python Dev/Filippo/MDD/visualize_web.py
+```
+
+Visit `http://localhost:8000` in your browser.  The landing page lists all
+patients with stored responses.  Selecting an ID shows one plot per questionnaire
+containing numeric scores.  Reload the page after new assessments to view the
+latest results.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
-requests
+matplotlib
+pandas


### PR DESCRIPTION
## Summary
- replace Flask server with a tiny `http.server` based implementation
- use `urllib` instead of `requests` for sending data
- document running the new lightweight server
- drop the `requests` dependency

## Testing
- `python -m py_compile Dev/Filippo/MDD/http_server.py Dev/Filippo/MDD/visualize_results.py Dev/Filippo/MDD/visualize_web.py Dev/Filippo/MDD/remote_storage.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685f851368a48327b1c4d78339663391