### PR TITLE
auto-generate patient ids

### DIFF
--- a/Dev/Filippo/MDD/BeckDepression.py
+++ b/Dev/Filippo/MDD/BeckDepression.py
@@ -4,17 +4,16 @@ import datetime
 import asyncio
 import uuid
 import os
+import sys
 
+sys.path.append(os.path.dirname(__file__))
 from remote_storage import send_to_server
 
 # Generate patient ID, preferring environment variable
 def get_patient_id() -> str:
     pid = os.environ.get("patient_id")
     if not pid:
-        pid = input("Enter patient identifier (or press Enter to generate one): ").strip()
-        if not pid:
-            pid = f"PAT-{uuid.uuid4().hex[:8]}"
-            print(f"Generated Patient ID: {pid}")
+        pid = f"PAT-{uuid.uuid4().hex[:8]}"
     return pid
 
 async def robot_say(text: str):

--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -3,19 +3,19 @@
 
 import asyncio
 import datetime
-from remote_storage import send_to_server
-import uuid
 import os
+import sys
+import uuid
+
+sys.path.append(os.path.dirname(__file__))
+from remote_storage import send_to_server
 
 
 def get_patient_id() -> str:
-    """Retrieve patient ID from environment or prompt the user."""
+    """Retrieve patient ID from environment or auto-generate."""
     pid = os.environ.get("patient_id")
     if not pid:
-        pid = input("Enter patient identifier (or press enter to generate one): ").strip()
-        if not pid:
-            pid = f"PAT-{uuid.uuid4().hex[:8]}"
-            print(f"Generated Patient ID: {pid}")
+        pid = f"PAT-{uuid.uuid4().hex[:8]}"
     return pid
 
 

--- a/Dev/Filippo/MDD/central_sensitization.py
+++ b/Dev/Filippo/MDD/central_sensitization.py
@@ -1,21 +1,21 @@
 # Central Sensitization Inventory (CSI) and Worksheet Script
 import asyncio
 import datetime
-from remote_storage import send_to_server
-import uuid
 import os
+import sys
+import uuid
+
+sys.path.append(os.path.dirname(__file__))
+from remote_storage import send_to_server
 
 
 
 
 def get_patient_id() -> str:
-    """Retrieve patient ID from the environment or prompt the user."""
+    """Retrieve patient ID from the environment or auto-generate."""
     pid = os.environ.get("patient_id")
     if not pid:
-        pid = input("Enter patient identifier (or press Enter to generate one): ").strip()
-        if not pid:
-            pid = f"PAT-{uuid.uuid4().hex[:8]}"
-            print(f"Generated Patient ID: {pid}")
+        pid = f"PAT-{uuid.uuid4().hex[:8]}"
     return pid
 
 def timestamp():

--- a/Dev/Filippo/MDD/dass21_assessment.py
+++ b/Dev/Filippo/MDD/dass21_assessment.py
@@ -1,9 +1,12 @@
 # DASS-21 Questionnaire Script with Automatic Scoring and SQLite Storage
 import asyncio
 import datetime
-from remote_storage import send_to_server
-import uuid
 import os
+import sys
+import uuid
+
+sys.path.append(os.path.dirname(__file__))
+from remote_storage import send_to_server
 
 
 
@@ -11,10 +14,7 @@ import os
 def get_patient_id() -> str:
     pid = os.environ.get("patient_id")
     if not pid:
-        pid = input("Enter patient identifier (or press Enter to auto-generate): ").strip()
-        if not pid:
-            pid = f"PAT-{uuid.uuid4().hex[:8]}"
-            print(f"Generated Patient ID: {pid}")
+        pid = f"PAT-{uuid.uuid4().hex[:8]}"
     return pid
 
 # Categories: d = depression, a = anxiety, s = stress

--- a/Dev/Filippo/MDD/eq5d5l_assessment.py
+++ b/Dev/Filippo/MDD/eq5d5l_assessment.py
@@ -1,9 +1,12 @@
 # eq5d5l_assessment.py
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
 from remote_storage import send_to_server
 import uuid
 import datetime
 import asyncio
-import os
 
 
 
@@ -63,10 +66,7 @@ def get_timestamp():
 async def collect_patient_id():
     pid = os.environ.get("patient_id")
     if not pid:
-        pid = input("Enter patient ID (or press Enter to auto-generate): ").strip()
-        if not pid:
-            pid = f"PAT-{uuid.uuid4().hex[:8]}"
-            print(f"[Info] Generated Patient ID: {pid}")
+        pid = f"PAT-{uuid.uuid4().hex[:8]}"
     return pid
 
 async def run_eq5d5l_questionnaire():

--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -1,5 +1,10 @@
 import asyncio
 import uuid
+import os
+import sys
+import sqlite3
+
+sys.path.append(os.path.dirname(__file__))
 from remote_storage import send_to_server
 import datetime
 
@@ -11,6 +16,8 @@ import eq5d5l_assessment
 import oswestry_disability_index
 import pain_catastrophizing
 import pittsburgh_sleep
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "patient_responses.db")
 
 
 async def robot_say(text: str):
@@ -29,20 +36,44 @@ async def robot_listen() -> str:
 def generate_patient_id():
     return f"PAT-{uuid.uuid4().hex[:8]}"
 
+def lookup_patient_id(first_name: str, last_name: str) -> str | None:
+    if not os.path.exists(DB_PATH):
+        return None
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT patient_id FROM patient_demographics WHERE name_first=? AND name_last=?",
+        (first_name, last_name),
+    )
+    row = cur.fetchone()
+    conn.close()
+    return row[0] if row else None
+
 async def collect_demographics():
     await robot_say("Welcome to the Pain & Mood Assessment System")
-    patient_id = input("Enter patient ID (or press Enter to auto-generate): ").strip()
-    if not patient_id:
-        patient_id = generate_patient_id()
-        print(f"Generated ID: {patient_id}")
-
-    date = datetime.date.today().strftime("%d/%m/%Y")
 
     await robot_say("Please tell me your last name")
     name_last = await robot_listen()
 
     await robot_say("What is your first name?")
     name_first = await robot_listen()
+
+    env_id = os.environ.get("patient_id")
+    existing = None
+    if env_id:
+        patient_id = env_id
+    else:
+        existing = lookup_patient_id(name_first, name_last)
+        if existing:
+            patient_id = existing
+            print(f"Matched existing patient ID: {patient_id}")
+            await robot_say(f"Welcome back {name_first}. Proceeding to the assessment.")
+            return patient_id
+        patient_id = generate_patient_id()
+        print(f"Generated ID: {patient_id}")
+    new_patient = env_id is None and existing is None
+
+    date = datetime.date.today().strftime("%d/%m/%Y")
 
     await robot_say(
         f"Hi {name_first}, nice to meet you. Today we will do a short interview to understand how you are feeling. Can I proceed with the assessment?"
@@ -111,32 +142,33 @@ async def collect_demographics():
     await robot_say("Do you need daily pain medication? 1 yes, 2 no")
     pain_med_daily = await robot_listen()
 
-    store_demographics(
-        patient_id,
-        {
-            "date": date,
-            "name_last": name_last,
-            "name_first": name_first,
-            "name_middle": name_middle,
-            "phone": phone,
-            "sex": sex,
-            "dob": dob,
-            "marital_status": marital_status,
-            "education": education,
-            "degree": degree,
-            "occupation": occupation,
-            "spouse_occupation": spouse_occupation,
-            "job_status": job_status,
-            "diagnosis_time": diagnosis_time,
-            "disease_pain": disease_pain,
-            "pain_symptom": pain_symptom,
-            "surgery": surgery,
-            "surgery_type": surgery_type,
-            "other_pain": other_pain,
-            "pain_med_week": pain_med_week,
-            "pain_med_daily": pain_med_daily,
-        },
-    )
+    if new_patient:
+        store_demographics(
+            patient_id,
+            {
+                "date": date,
+                "name_last": name_last,
+                "name_first": name_first,
+                "name_middle": name_middle,
+                "phone": phone,
+                "sex": sex,
+                "dob": dob,
+                "marital_status": marital_status,
+                "education": education,
+                "degree": degree,
+                "occupation": occupation,
+                "spouse_occupation": spouse_occupation,
+                "job_status": job_status,
+                "diagnosis_time": diagnosis_time,
+                "disease_pain": disease_pain,
+                "pain_symptom": pain_symptom,
+                "surgery": surgery,
+                "surgery_type": surgery_type,
+                "other_pain": other_pain,
+                "pain_med_week": pain_med_week,
+                "pain_med_daily": pain_med_daily,
+            },
+        )
 
     return patient_id
 
@@ -168,6 +200,12 @@ async def main():
         return
     await run_all_assessments(patient_id)
     print("\n✅ All assessments completed.")
+
+
+class Activity:
+    async def on_start(self):
+        await main()
+        self.stop()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/Dev/Filippo/MDD/oswestry_disability_index.py
+++ b/Dev/Filippo/MDD/oswestry_disability_index.py
@@ -1,7 +1,10 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
 from remote_storage import send_to_server
 import uuid
 import datetime
-import os
 
 
 
@@ -9,10 +12,7 @@ import os
 def get_patient_id() -> str:
     pid = os.environ.get("patient_id")
     if not pid:
-        pid = input("Enter patient identifier (or press enter to generate one): ").strip()
-        if not pid:
-            pid = f"PAT-{uuid.uuid4().hex[:8]}"
-            print(f"Generated Patient ID: {pid}")
+        pid = f"PAT-{uuid.uuid4().hex[:8]}"
     return pid
 
 def get_timestamp():

--- a/Dev/Filippo/MDD/pain_catastrophizing.py
+++ b/Dev/Filippo/MDD/pain_catastrophizing.py
@@ -1,10 +1,13 @@
 # Pain Catastrophizing Scale (PCS) – Full Implementation with Scoring and DB Storage
 
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
 from remote_storage import send_to_server
 import datetime
 import uuid
 import asyncio
-import os
 
 
 
@@ -12,10 +15,7 @@ import os
 def get_patient_id() -> str:
     pid = os.environ.get("patient_id")
     if not pid:
-        pid = input("Enter patient identifier (or press Enter to generate one): ").strip()
-        if not pid:
-            pid = f"PAT-{uuid.uuid4().hex[:8]}"
-            print(f"Generated Patient ID: {pid}")
+        pid = f"PAT-{uuid.uuid4().hex[:8]}"
     return pid
 
 # PCS questions

--- a/Dev/Filippo/MDD/pittsburgh_sleep.py
+++ b/Dev/Filippo/MDD/pittsburgh_sleep.py
@@ -1,10 +1,13 @@
 # Pittsburgh Sleep Quality Index (PSQI) implementation script
 import asyncio
 import datetime
-from remote_storage import send_to_server
+import os
+import sys
 import uuid
 from typing import Literal
-import os
+
+sys.path.append(os.path.dirname(__file__))
+from remote_storage import send_to_server
 
 
 
@@ -24,10 +27,7 @@ def get_timestamp():
 def get_patient_id():
     pid = os.environ.get("patient_id")
     if not pid:
-        pid = input("Enter patient identifier (or press Enter to generate one): ").strip()
-        if not pid:
-            pid = f"PAT-{uuid.uuid4().hex[:8]}"
-            print(f"Generated Patient ID: {pid}")
+        pid = f"PAT-{uuid.uuid4().hex[:8]}"
     return pid
 
 # Map responses to scores as per PSQI guidance

--- a/Dev/Filippo/MDD/remote_storage.py
+++ b/Dev/Filippo/MDD/remote_storage.py
@@ -1,13 +1,17 @@
 import os
-import requests
+import json
+from urllib import request
 
 SERVER_URL = os.environ.get("SERVER_URL", "http://localhost:5000/store")
 
 
 def send_to_server(table: str, **data) -> None:
     """Send a row of questionnaire data to the remote HTTP server."""
-    payload = {"table": table, **data}
+    payload = json.dumps({"table": table, **data}).encode("utf-8")
+    req = request.Request(
+        SERVER_URL, data=payload, headers={"Content-Type": "application/json"}
+    )
     try:
-        requests.post(SERVER_URL, json=payload, timeout=5)
+        request.urlopen(req, timeout=5)
     except Exception as exc:
         print(f"[WARN] Failed to send data to {SERVER_URL}: {exc}")

--- a/Dev/Filippo/MDD/visualize_results.py
+++ b/Dev/Filippo/MDD/visualize_results.py
@@ -1,74 +1,10 @@
-import sqlite3
-import pandas as pd
-import matplotlib.pyplot as plt
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-import tkinter as tk
-from tkinter import ttk
+import os
+import sys
 
-DB_NAME = "patient_responses.db"
+# Ensure local imports work when run directly
+sys.path.append(os.path.dirname(__file__))
 
-def get_available_tables(conn):
-    cursor = conn.cursor()
-    cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-    return [row[0] for row in cursor.fetchall() if row[0].startswith("responses_")]
-
-def get_all_patient_ids(conn, tables):
-    cursor = conn.cursor()
-    union_query = " UNION ".join([f"SELECT DISTINCT patient_id FROM {table}" for table in tables])
-    cursor.execute(f"SELECT DISTINCT patient_id FROM ({union_query})")
-    return [str(row[0]) for row in cursor.fetchall()]
-
-def plot_data_for_table(patient_id, conn, table_name):
-    query = f"SELECT question_title, score FROM {table_name} WHERE patient_id = ?"
-    df = pd.read_sql_query(query, conn, params=(patient_id,))
-    
-    fig, ax = plt.subplots(figsize=(9, 5))
-    if df.empty:
-        ax.text(0.5, 0.5, f"No data found for {table_name}", ha='center', va='center')
-        return fig
-
-    df['question_title'] = df['question_title'].str[:40]  # Trim long titles
-    ax.bar(df['question_title'], df['score'], color='skyblue')
-    ax.set_title(table_name.replace("responses_", "").upper())
-    ax.set_ylabel("Score")
-    ax.tick_params(axis='x', labelrotation=90)
-    ax.grid(True, axis='y', linestyle='--', alpha=0.7)
-    plt.tight_layout()
-    return fig
-
-def launch_gui():
-    conn = sqlite3.connect(DB_NAME)
-    tables = get_available_tables(conn)
-    patient_ids = get_all_patient_ids(conn, tables)
-
-    root = tk.Tk()
-    root.title("Patient Results Dashboard")
-    root.geometry("1200x800")
-
-    selected_id = tk.StringVar()
-    ttk.Label(root, text="Select Patient ID:").pack(pady=5)
-    dropdown = ttk.Combobox(root, textvariable=selected_id, values=patient_ids, state="readonly")
-    dropdown.pack(pady=5)
-
-    notebook = ttk.Notebook(root)
-    notebook.pack(fill=tk.BOTH, expand=True)
-
-    def on_id_selected(event=None):
-        for tab in notebook.tabs():
-            notebook.forget(tab)
-
-        for table in tables:
-            frame = ttk.Frame(notebook)
-            notebook.add(frame, text=table.replace("responses_", "").upper())
-
-            fig = plot_data_for_table(selected_id.get(), conn, table)
-            canvas = FigureCanvasTkAgg(fig, master=frame)
-            canvas.draw()
-            canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
-
-    dropdown.bind("<<ComboboxSelected>>", on_id_selected)
-
-    root.mainloop()
+from web_dashboard import run
 
 if __name__ == "__main__":
-    launch_gui()
+    run()

--- a/Dev/Filippo/MDD/web_dashboard.py
+++ b/Dev/Filippo/MDD/web_dashboard.py
@@ -1,0 +1,186 @@
+import json
+import re
+import sqlite3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+DB_NAME = "patient_responses.db"
+
+
+def get_response_tables(conn):
+    """Return all table names that store questionnaire responses."""
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    return [row[0] for row in cur.fetchall() if row[0].startswith('responses_')]
+
+
+def get_all_patient_ids(conn, tables):
+    """Gather every patient_id appearing in the given tables."""
+    if not tables:
+        return []
+    cur = conn.cursor()
+    union_query = " UNION ".join([f"SELECT patient_id FROM {t}" for t in tables])
+    cur.execute(f"SELECT DISTINCT patient_id FROM ({union_query}) AS ids")
+    return [str(row[0]) for row in cur.fetchall() if row[0] is not None]
+
+
+def get_data_for_table(patient_id, conn, table_name):
+    """Return label and score lists for the given patient and table."""
+    cur = conn.cursor()
+    cols = [row[1] for row in cur.execute(f"PRAGMA table_info({table_name})")]
+    if "score" not in cols:
+        return None
+    q_col = next((c for c in ("question_title", "question_text", "dimension") if c in cols), None)
+    if not q_col:
+        return None
+    cur.execute(
+        f"SELECT {q_col}, score FROM {table_name} WHERE patient_id=?",
+        (patient_id,),
+    )
+    rows = cur.fetchall()
+    if not rows:
+        return None
+    labels = [str(r[0])[:40] for r in rows]
+    scores = [r[1] for r in rows]
+    return {"labels": labels, "scores": scores}
+
+
+INDEX_TEMPLATE = """<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <link href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css' rel='stylesheet'>
+  <title>Patient Dashboard</title>
+</head>
+<body class='bg-light'>
+<nav class='navbar navbar-dark bg-primary mb-4'>
+  <div class='container'>
+    <span class='navbar-brand mb-0 h1'>Patient Dashboard</span>
+  </div>
+</nav>
+<div class='container'>
+  <h2 class='mb-3'>Select a patient</h2>
+  <ul class='list-group'>
+  {patient_list}
+  </ul>
+</div>
+</body>
+</html>"""
+
+PATIENT_TEMPLATE = """<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <link href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css' rel='stylesheet'>
+  <script src='https://cdn.jsdelivr.net/npm/chart.js'></script>
+  <title>Results for {patient_id}</title>
+</head>
+<body class='bg-light'>
+<nav class='navbar navbar-dark bg-primary mb-4'>
+  <div class='container'>
+    <a class='navbar-brand' href='/'>Patient Dashboard</a>
+  </div>
+</nav>
+<div class='container'>
+  <h2 class='mb-4'>Results for {patient_id}</h2>
+  {chart_divs}
+  <a class='btn btn-secondary' href='/'>Back</a>
+</div>
+<script>
+  const chartData = {charts_json};
+  Object.entries(chartData).forEach(([table, data], idx) => {
+    const ctx = document.getElementById('chart-' + (idx + 1));
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: data.labels,
+        datasets: [{
+          label: 'Score',
+          data: data.scores,
+          backgroundColor: '#0d6efd'
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: { y: { beginAtZero: true } }
+      }
+    });
+  });
+</script>
+</body>
+</html>"""
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path in ('/', '/index.html'):
+            self.send_index()
+        else:
+            m = re.match(r'^/patient/(.+)$', self.path)
+            if m:
+                self.send_patient(m.group(1))
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+    def _write_html(self, html: str) -> None:
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.end_headers()
+        self.wfile.write(html.encode('utf-8'))
+
+    def send_index(self):
+        conn = sqlite3.connect(DB_NAME)
+        tables = get_response_tables(conn)
+        patient_ids = get_all_patient_ids(conn, tables)
+        conn.close()
+        if patient_ids:
+            items = '\n'.join(
+                f"<li class='list-group-item'><a class='text-decoration-none' href='/patient/{pid}'>{pid}</a></li>"
+                for pid in patient_ids
+            )
+        else:
+            items = "<li class='list-group-item'>No patients found.</li>"
+        html = INDEX_TEMPLATE.format(patient_list=items)
+        self._write_html(html)
+
+    def send_patient(self, patient_id: str):
+        conn = sqlite3.connect(DB_NAME)
+        tables = get_response_tables(conn)
+        charts = {}
+        for table in tables:
+            data = get_data_for_table(patient_id, conn, table)
+            if data:
+                charts[table] = data
+        conn.close()
+        if charts:
+            divs = ''
+            for idx, table in enumerate(charts, start=1):
+                label = table.replace('responses_', '').upper()
+                divs += (
+                    "<div class='card mb-4'>"
+                    f"<div class='card-header fw-bold'>{label}</div>"
+                    "<div class='card-body'>"
+                    f"<canvas id='chart-{idx}'></canvas>"
+                    "</div></div>"
+                )
+        else:
+            divs = "<p>No results found.</p>"
+        html = PATIENT_TEMPLATE.format(
+            patient_id=patient_id,
+            chart_divs=divs,
+            charts_json=json.dumps(charts),
+        )
+        self._write_html(html)
+
+
+def run(port: int = 8000) -> None:
+    """Start the dashboard server on the given port."""
+    server = HTTPServer(('0.0.0.0', port), DashboardHandler)
+    print(f"Dashboard listening on http://localhost:{port}")
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    run()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
 # MDD_Diagnosis
+
+## Running the HTTP server
+
+Questionnaire results are collected by `Dev/Filippo/MDD/http_server.py`.  The
+server relies only on the Python standard library and stores incoming data in
+`patient_responses.db`.
+
+1. Launch the server:
+
+   ```bash
+   python Dev/Filippo/MDD/http_server.py
+   ```
+
+   The application listens on port `5000` and creates the SQLite database if it
+   does not already exist.
+
+## Configuring `SERVER_URL`
+
+Assessment scripts transmit each response to the URL stored in the
+`SERVER_URL` environment variable (default: `http://localhost:5000/store`).  Set
+this variable before running a questionnaire so that data reaches the server:
+
+```bash
+export SERVER_URL="http://<server-ip>:5000/store"
+```
+
+Replace `<server-ip>` with the host running `http_server.py`.
+
+## Verifying stored data
+
+After completing one or more questionnaires, check that the answers were
+recorded:
+
+```bash
+sqlite3 patient_responses.db ".tables"
+sqlite3 patient_responses.db "SELECT * FROM patient_demographics LIMIT 5;"
+```
+
+The first command shows all tables created by the server.  You can then run
+standard SQLite queries to inspect the contents and confirm that data was saved.
+
+## Patient identifiers
+
+When running `main.py` the system asks for the patient's first and last name and
+automatically generates an ID in the format `PAT-xxxxxx`.  If the database
+already contains a record with the same first and last name, that existing ID is
+reused so repeated visits are linked to the correct patient.  To run any
+questionnaire independently you can set the environment variable `patient_id`
+before execution.
+
+## Web dashboard
+
+You can view interactive charts of questionnaire results through a small
+dashboard script that relies only on Python's standard library. It reads from
+the same `patient_responses.db` database created by `http_server.py` and groups
+results by `patient_id`.
+
+```bash
+python Dev/Filippo/MDD/web_dashboard.py
+```
+
+Visit `http://localhost:8000` in your browser.  The landing page lists all
+patients with stored responses.  Selecting an ID shows one plot per questionnaire
+containing numeric scores.  Reload the page after new assessments to view the
+latest results.
+
+You can also launch the same dashboard with `visualize_results.py`, which simply
+imports the `run` function and starts the server on the default port.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-Flask
-requests


### PR DESCRIPTION
## Summary
- automatically reuse patient IDs when first and last name match
- drop all prompts for manual patient ID entry across questionnaires
- store demographics only when creating a new patient record
- document automatic ID generation in README

## Testing
- `python -m py_compile Dev/Filippo/MDD/http_server.py Dev/Filippo/MDD/visualize_results.py Dev/Filippo/MDD/web_dashboard.py Dev/Filippo/MDD/remote_storage.py`
- `python -m py_compile Dev/Filippo/MDD/*.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685f851368a48327b1c4d78339663391