### PR TITLE
Handle ASR timeouts in questionnaires

### DIFF
--- a/Dev/Filippo/MDD/BeckDepression.py
+++ b/Dev/Filippo/MDD/BeckDepression.py
@@ -20,17 +20,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 
 # Generate patient ID, preferring environment variable
 def get_patient_id() -> str:

--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -21,17 +21,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 
 
 def get_patient_id() -> str:

--- a/Dev/Filippo/MDD/eq5d5l_assessment.py
+++ b/Dev/Filippo/MDD/eq5d5l_assessment.py
@@ -16,17 +16,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 import uuid
 import datetime
 import asyncio
@@ -48,17 +64,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 import uuid
 import datetime
 import asyncio
@@ -80,17 +112,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 import uuid
 import datetime
 import asyncio

--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -21,17 +21,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 import datetime
 
 import BeckDepression

--- a/Dev/Filippo/MDD/oswestry_disability_index.py
+++ b/Dev/Filippo/MDD/oswestry_disability_index.py
@@ -15,17 +15,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 import uuid
 import datetime
 

--- a/Dev/Filippo/MDD/pain_catastrophizing.py
+++ b/Dev/Filippo/MDD/pain_catastrophizing.py
@@ -17,17 +17,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 import datetime
 import uuid
 import asyncio

--- a/Dev/Filippo/MDD/pittsburgh_sleep.py
+++ b/Dev/Filippo/MDD/pittsburgh_sleep.py
@@ -20,17 +20,33 @@ async def robot_say(text: str) -> None:
 
 
 async def robot_listen() -> str:
-    """Block until a spoken utterance is received."""
+    """Listen for speech and return the transcript once recognized."""
     while True:
-        try:
-            evt = await system.wait_for_event("speech_recognized")
-            if isinstance(evt, dict):
-                text = evt.get("text", "").strip()
-                if text:
-                    return text
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        await robot_say("I didn't catch that, please repeat.")
 
 
 

--- a/Dev/Filippo/MDD/speech_utils.py
+++ b/Dev/Filippo/MDD/speech_utils.py
@@ -10,10 +10,29 @@ async def robot_say(text: str) -> None:
 
 async def robot_listen() -> str:
     """Return the next transcribed utterance from the speech recognizer."""
-    try:
-        evt = await system.wait_for_event("speech_recognized")
-        if isinstance(evt, dict):
-            return evt.get("text", "").strip()
-    except Exception:
-        pass
-    return ""
+    while True:
+        speech_task = asyncio.create_task(
+            system.wait_for_event("speech_recognized", timeout=10)
+        )
+        no_speech_task = asyncio.create_task(
+            system.wait_for_event("no_speech_heard", timeout=10)
+        )
+
+        done, pending = await asyncio.wait(
+            {speech_task, no_speech_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+
+        if speech_task in done:
+            try:
+                evt = speech_task.result()
+                if isinstance(evt, dict):
+                    text = evt.get("text", "").strip()
+                    if text:
+                        return text
+            except Exception:
+                pass
+
+        print("[Ameca]: I didn't catch that, please repeat.")


### PR DESCRIPTION
## Summary
- update robot_listen in questionnaire modules to wait up to 10s for speech
- reprompt if no_speech_heard or timeout occurs so user responses are captured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fca8d7fb08327b1564702c6281c21