### PR TITLE
Fix robot_listen timeout call

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -24,14 +24,15 @@ async def robot_listen() -> str:
     """Listen for speech and return the transcript once recognized."""
     while True:
         speech_task = asyncio.create_task(
-            system.wait_for_event("speech_recognized", timeout=10)
+            system.wait_for_event("speech_recognized")
         )
         no_speech_task = asyncio.create_task(
-            system.wait_for_event("no_speech_heard", timeout=10)
+            system.wait_for_event("no_speech_heard")
         )
 
         done, pending = await asyncio.wait(
             {speech_task, no_speech_task},
+            timeout=10,
             return_when=asyncio.FIRST_COMPLETED,
         )
         for task in pending:


### PR DESCRIPTION
## Summary
- remove unsupported `timeout` argument from `system.wait_for_event`
- implement timeout via `asyncio.wait`

## Testing
- `python -m py_compile Dev/Filippo/MDD/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685fc8a16dd0832788abe29cc79ec84c