### PR TITLE
Fix optional matplotlib and improve robot integration

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -8,7 +8,8 @@ import sqlite3
 try:  # allow running outside the robot system
     system  # type: ignore[name-defined]
 except NameError:  # pragma: no cover - only executed locally
-    system = None
+    import builtins
+    system = getattr(builtins, "system", None)
 
 if system is None:
     import importlib.util
@@ -27,6 +28,8 @@ if system is None:
             return module
 
     system = _LocalSystem()
+    import builtins
+    builtins.system = system
 
 sys.path.append(os.path.dirname(__file__))
 from remote_storage import send_to_server
@@ -35,6 +38,7 @@ if system is not None:
         ROBOT_STATE = system.import_library("../../../HB3/robot_state.py")
         robot_state = ROBOT_STATE.state  # noqa: F401  - used when running on the robot
     except Exception:
+        print("[WARN] Failed to load robot_state")
         robot_state = None
 
 from speech_utils import robot_say, robot_listen

--- a/Dev/Filippo/MDD/speech_utils.py
+++ b/Dev/Filippo/MDD/speech_utils.py
@@ -12,7 +12,7 @@ async def robot_say(text: str) -> None:
         try:
             system.messaging.post("tts_say", [text, "eng"])
         except Exception:
-            pass
+            print("[WARN] Failed to send TTS message")
 
 async def robot_listen() -> str:
     """Return the next transcribed utterance from the speech recognizer."""

--- a/Dev/Filippo/MDD/visualize_web.py
+++ b/Dev/Filippo/MDD/visualize_web.py
@@ -1,7 +1,12 @@
 import sqlite3
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
+
+try:  # matplotlib is optional on the robot
+    import matplotlib
+    matplotlib.use("Agg")  # use non-GUI backend
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - if matplotlib isn't available
+    plt = None
+
 from flask import Flask, render_template_string
 import base64
 import io
@@ -25,6 +30,8 @@ def get_all_patient_ids(conn, tables):
 
 def plot_data_for_table(patient_id, conn, table_name):
     """Create a bar chart for the given patient from the specified table."""
+    if plt is None:
+        return None
     cols = [row[1] for row in conn.execute(f"PRAGMA table_info({table_name})")]
     if 'score' not in cols:
         return None  # skip tables without numeric scores


### PR DESCRIPTION
## Summary
- handle missing matplotlib gracefully in `visualize_web.py`
- improve detection of the Tritium `system` object in `main.py`
- warn if robot state or tts messaging fails

## Testing
- `python -m py_compile Dev/Filippo/MDD/main.py Dev/Filippo/MDD/visualize_web.py Dev/Filippo/MDD/speech_utils.py`
- `python Dev/Filippo/MDD/main.py 2>&1 | head` *(fails: WARN messages printed)*
- `python Dev/Filippo/MDD/visualize_web.py --help | head` *(fails: Flask missing)*


------
https://chatgpt.com/codex/tasks/task_e_686108fd7dd88327903738f05fbb1053