### PR TITLE
Fix path handling for Tritium

### DIFF
--- a/Dev/Filippo/MDD/BeckDepression.py
+++ b/Dev/Filippo/MDD/BeckDepression.py
@@ -7,7 +7,12 @@ import uuid
 import os
 import sys
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen
 

--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -8,7 +8,12 @@ import os
 import sys
 import uuid
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen
 

--- a/Dev/Filippo/MDD/central_sensitization.py
+++ b/Dev/Filippo/MDD/central_sensitization.py
@@ -6,7 +6,12 @@ import os
 import sys
 import uuid
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen
 

--- a/Dev/Filippo/MDD/dass21_assessment.py
+++ b/Dev/Filippo/MDD/dass21_assessment.py
@@ -6,7 +6,12 @@ import os
 import sys
 import uuid
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen
 

--- a/Dev/Filippo/MDD/eq5d5l_assessment.py
+++ b/Dev/Filippo/MDD/eq5d5l_assessment.py
@@ -4,7 +4,12 @@ import os
 import sys
 import uuid
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen
 

--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -19,7 +19,7 @@ if system is None:
 
         @staticmethod
         def import_library(rel_path: str):
-            base_dir = os.path.dirname(__file__)
+            base_dir = os.path.dirname(os.path.abspath(__file__)) if "__file__" in globals() else os.getcwd()
             abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
             module_name = os.path.splitext(os.path.basename(rel_path))[0]
             spec = importlib.util.spec_from_file_location(module_name, abs_path)
@@ -31,7 +31,12 @@ if system is None:
     import builtins
     builtins.system = system
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:  # __file__ may be undefined in some environments
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 if system is not None:
     try:
@@ -56,7 +61,7 @@ import oswestry_disability_index
 import pain_catastrophizing
 import pittsburgh_sleep
 
-DB_PATH = os.path.join(os.path.dirname(__file__), "patient_responses.db")
+DB_PATH = os.path.join(MODULE_DIR, "patient_responses.db")
 
 DIGIT_WORDS = {
     "zero": "0",

--- a/Dev/Filippo/MDD/oswestry_disability_index.py
+++ b/Dev/Filippo/MDD/oswestry_disability_index.py
@@ -2,7 +2,12 @@
 import os
 import sys
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen
 import uuid

--- a/Dev/Filippo/MDD/pain_catastrophizing.py
+++ b/Dev/Filippo/MDD/pain_catastrophizing.py
@@ -4,7 +4,12 @@
 import os
 import sys
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen
 import datetime

--- a/Dev/Filippo/MDD/pittsburgh_sleep.py
+++ b/Dev/Filippo/MDD/pittsburgh_sleep.py
@@ -7,7 +7,12 @@ import sys
 import uuid
 from typing import Literal
 
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen
 

--- a/Dev/Filippo/MDD/visualize_results.py
+++ b/Dev/Filippo/MDD/visualize_results.py
@@ -2,7 +2,12 @@ import os
 import sys
 
 # Ensure local imports work when run directly
-sys.path.append(os.path.dirname(__file__))
+try:
+    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    MODULE_DIR = os.getcwd()
+if MODULE_DIR not in sys.path:
+    sys.path.append(MODULE_DIR)
 
 from web_dashboard import run
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ patients with stored responses.  Selecting an ID shows one plot per questionnair
 containing numeric scores.  Reload the page after new assessments to view the
 latest results.
 
-You can also launch the same dashboard with `visualize_results.py`, which simply
-
-imports the `run` function and starts the server on the default port.
+You can also launch the same dashboard with `visualize_results.py` or
+`visualize_web.py`, both of which simply import the `run` function and start the
+server on the default port.
 


### PR DESCRIPTION
## Summary
- safeguard `__file__` usages in MDD modules
- mention `visualize_web.py` in README

## Testing
- `python -m py_compile Dev/Filippo/MDD/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686112873c108327adbf7efedb03bce5