### PR TITLE
Add AUTO_MODE to skip demographic prompts

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -241,9 +241,15 @@ async def run_all_assessments(patient_id: str):
     await BeckDepression.run_beck_depression_inventory()
 
 async def main():
-    patient_id = await collect_demographics()
-    if not patient_id:
-        return
+    """Entry point for running all questionnaires."""
+    auto_mode = os.environ.get("AUTO_MODE", "").lower() in {"1", "true", "yes"}
+    if auto_mode:
+        patient_id = os.environ.get("patient_id", generate_patient_id())
+    else:
+        patient_id = await collect_demographics()
+        if not patient_id:
+            return
+
     await run_all_assessments(patient_id)
     await robot_say("All assessments completed.")
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ reused so repeated visits are linked to the correct patient.  To run any
 questionnaire independently you can set the environment variable `patient_id`
 before execution.
 
+To skip collection of demographic details entirely, set `AUTO_MODE=1` when
+running `main.py`.  In this mode a random patient ID is generated (unless
+`patient_id` is already defined) and the questionnaires start immediately.
+
 ## Web dashboard
 
 


### PR DESCRIPTION
## Summary
- allow skipping demographic collection with `AUTO_MODE` environment variable
- document the new environment variable in README

## Testing
- `python -m py_compile Dev/Filippo/MDD/main.py`
- `python -m compileall Dev/Filippo/MDD`

------
https://chatgpt.com/codex/tasks/task_e_68611cfe3f2c8327bdd9347caeb909cf