### PR TITLE
Fix local imports and remove Flask usage

### DIFF
--- a/Dev/Filippo/MDD/BeckDepression.py
+++ b/Dev/Filippo/MDD/BeckDepression.py
@@ -42,27 +42,27 @@ async def store_response_to_db(patient_id: str, question_number: int, question_t
 
 
 bdi_questions = [
-    ("Sadness", ["I do not feel sad.", "I feel sad.", "I am sad all the time and can't snap out of it.", "I am so sad and unhappy that I can't stand it."]),
-    ("Pessimism", ["I am not particularly discouraged about the future.", "I feel discouraged about the future.", "I feel I have nothing to look forward to.", "I feel the future is hopeless and that things cannot be done."]),
-    ("Failure", ["I do not feel like a failure.", "I feel I have failed more than the average person.", "As I look back on my life, all I can see is a lot of failures.", "I feel I am a complete failure as a person."]),
-    ("Satisfaction", ["I get as much satisfaction out of things as I used to.", "I don’t enjoy things the way I used to.", "I don't get real satisfaction out of anything anymore.", "I am dissatisfied or bored with everything."]),
-    ("Guilt", ["I don’t feel particularly guilty.", "I feel guilty a good part of the time.", "I feel quite guilty most of the time.", "I feel guilty all of the time."]),
-    ("Punishment", ["I don’t feel I am being punished.", "I feel I may be punished.", "I expect to be punished.", "I feel I am being punished."]),
-    ("Self-disappointment", ["I don’t feel disappointed in myself.", "I am disappointed in myself.", "I am disgusted with myself.", "I hate myself."]),
-    ("Self-criticism", ["I don’t feel I am any worse than anybody else.", "I am critical of myself for my weakness or mistakes.", "I blame myself all the time for my faults.", "I blame myself for everything bad that happens."]),
-    ("Suicidal thoughts", ["I don’t have any thoughts of killing myself.", "I have thoughts of killing myself, but I would not carry them out.", "I would like to kill myself.", "I would kill myself if I had the chance."]),
-    ("Crying", ["I don’t cry any more than usual.", "I cry more now than I used to.", "I cry all the time now.", "I used to be able to cry, but now I can’t cry even though I want to."]),
-    ("Irritability", ["I am no more irritated by things than I ever was.", "I am slightly more irritated now than usual.", "I am quite annoyed or irritated a good deal of the time.", "I feel irritated all the time."]),
-    ("Social withdrawal", ["I have not lost interest in other people.", "I am less interested in other people than I used to be.", "I have lost most of my interest in other people.", "I have lost all of my interest in other people."]),
-    ("Decision making", ["I make decisions about as well as I ever could.", "I put off making decisions more than I used to.", "I have greater difficulty in making decisions more than I used to.", "I can't make decisions at all anymore."]),
-    ("Body image", ["I don’t feel that I look any worse than I used to.", "I am worried that I am looking old or unattractive.", "I feel there are permanent changes in my appearance that make me look unattractive.", "I believe that I look ugly."]),
-    ("Work capacity", ["I can work about as well as before.", "It takes an extra effort to get started at doing something.", "I have to push myself very hard to do anything.", "I can't do any work at all."]),
-    ("Sleep", ["I can sleep as well as usual.", "I don’t sleep as well as I used to.", "I wake up 1–2 hours earlier than usual and find it hard to get back to sleep.", "I wake up several hours earlier than I used to and cannot get back to sleep."]),
-    ("Fatigue", ["I don't get more tired than usual.", "I get tired more easily than I used to.", "I get tired from doing almost anything.", "I am too tired to do anything."]),
-    ("Appetite", ["My appetite is no worse than usual.", "My appetite is not as good as it used to be.", "My appetite is much worse now.", "I have no appetite at all anymore."]),
-    ("Weight loss", ["I haven't lost much weight, if any, lately.", "I have lost more than five pounds.", "I have lost more than ten pounds.", "I have lost more than fifteen pounds."]),
-    ("Health concerns", ["I am no more worried about my health than usual.", "I am worried about physical problems like aches, pain, upset stomach or constipation.", "I am very worried about physical problems and it's hard to think of much else.", "I am so worried about my physical problems that I cannot think of anything else."]),
-    ("Sexual interest", ["I have not noticed any recent changes in my interest in sex.", "I am less interested in sex than I used to be.", "I have almost no interest in sex.", "I have lost interest in sex completely."])
+    ("How sad have you been feeling?", ["I do not feel sad.", "I feel sad.", "I am sad all the time and can't snap out of it.", "I am so sad and unhappy that I can't stand it."]),
+    ("How pessimistic do you feel about the future?", ["I am not particularly discouraged about the future.", "I feel discouraged about the future.", "I feel I have nothing to look forward to.", "I feel the future is hopeless and that things cannot be done."]),
+    ("Do you feel like a failure?", ["I do not feel like a failure.", "I feel I have failed more than the average person.", "As I look back on my life, all I can see is a lot of failures.", "I feel I am a complete failure as a person."]),
+    ("How satisfied do you feel with your life?", ["I get as much satisfaction out of things as I used to.", "I don’t enjoy things the way I used to.", "I don't get real satisfaction out of anything anymore.", "I am dissatisfied or bored with everything."]),
+    ("How often do you feel guilty?", ["I don’t feel particularly guilty.", "I feel guilty a good part of the time.", "I feel quite guilty most of the time.", "I feel guilty all of the time."]),
+    ("Do you feel you are being punished?", ["I don’t feel I am being punished.", "I feel I may be punished.", "I expect to be punished.", "I feel I am being punished."]),
+    ("How disappointed are you in yourself?", ["I don’t feel disappointed in myself.", "I am disappointed in myself.", "I am disgusted with myself.", "I hate myself."]),
+    ("How critical are you of yourself?", ["I don’t feel I am any worse than anybody else.", "I am critical of myself for my weakness or mistakes.", "I blame myself all the time for my faults.", "I blame myself for everything bad that happens."]),
+    ("Have you had thoughts of killing yourself?", ["I don’t have any thoughts of killing myself.", "I have thoughts of killing myself, but I would not carry them out.", "I would like to kill myself.", "I would kill myself if I had the chance."]),
+    ("How often do you feel like crying?", ["I don’t cry any more than usual.", "I cry more now than I used to.", "I cry all the time now.", "I used to be able to cry, but now I can’t cry even though I want to."]),
+    ("How irritable do you feel?", ["I am no more irritated by things than I ever was.", "I am slightly more irritated now than usual.", "I am quite annoyed or irritated a good deal of the time.", "I feel irritated all the time."]),
+    ("How much have you lost interest in other people?", ["I have not lost interest in other people.", "I am less interested in other people than I used to be.", "I have lost most of my interest in other people.", "I have lost all of my interest in other people."]),
+    ("How difficult is it for you to make decisions?", ["I make decisions about as well as I ever could.", "I put off making decisions more than I used to.", "I have greater difficulty in making decisions more than I used to.", "I can't make decisions at all anymore."]),
+    ("How do you feel about your appearance?", ["I don’t feel that I look any worse than I used to.", "I am worried that I am looking old or unattractive.", "I feel there are permanent changes in my appearance that make me look unattractive.", "I believe that I look ugly."]),
+    ("How capable do you feel of working?", ["I can work about as well as before.", "It takes an extra effort to get started at doing something.", "I have to push myself very hard to do anything.", "I can't do any work at all."]),
+    ("How well are you sleeping?", ["I can sleep as well as usual.", "I don’t sleep as well as I used to.", "I wake up 1–2 hours earlier than usual and find it hard to get back to sleep.", "I wake up several hours earlier than I used to and cannot get back to sleep."]),
+    ("How tired do you feel?", ["I don't get more tired than usual.", "I get tired more easily than I used to.", "I get tired from doing almost anything.", "I am too tired to do anything."]),
+    ("How is your appetite?", ["My appetite is no worse than usual.", "My appetite is not as good as it used to be.", "My appetite is much worse now.", "I have no appetite at all anymore."]),
+    ("Have you experienced weight loss recently?", ["I haven't lost much weight, if any, lately.", "I have lost more than five pounds.", "I have lost more than ten pounds.", "I have lost more than fifteen pounds."]),
+    ("How worried are you about your health?", ["I am no more worried about my health than usual.", "I am worried about physical problems like aches, pain, upset stomach or constipation.", "I am very worried about physical problems and it's hard to think of much else.", "I am so worried about my physical problems that I cannot think of anything else."]),
+    ("How is your interest in sex?", ["I have not noticed any recent changes in my interest in sex.", "I am less interested in sex than I used to be.", "I have almost no interest in sex.", "I have lost interest in sex completely."])
 ]
 
 

--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -42,12 +42,12 @@ bpi_questions = [
     "8. What relieves your pain? (free response):",
     "9a. In the last 24 hours, how much relief have pain treatments given you? (0%–100%):",
     "10a. Pain interfered with General Activity (0 = No interference, 10 = Complete interference):",
-    "10b. Mood:",
-    "10c. Walking ability:",
-    "10d. Normal work:",
-    "10e. Relations with others:",
-    "10f. Sleep:",
-    "10g. Enjoyment of life:",
+    "10b. How has your mood been affected by pain?",
+    "10c. How has pain affected your walking ability?",
+    "10d. How has pain interfered with your normal work?",
+    "10e. How has pain affected your relations with others?",
+    "10f. How has pain affected your sleep?",
+    "10g. How has pain affected your enjoyment of life?",
     "11. Are you currently taking pain medications? (Yes/No):",
     "12a. If yes, list your current medications:",
     "12b. How often do you take these medications?:",
@@ -61,8 +61,12 @@ bpi_questions = [
 
 async def run_bpi():
     patient_id = get_patient_id()
-    for i, question in enumerate(bpi_questions):
-        await robot_say(f"{question}")
+
+    index = 0
+    qnum = 1
+    while index < len(bpi_questions):
+        question = bpi_questions[index]
+        await robot_say(question)
         response = await robot_listen()
         await robot_say("Thank you.")
         timestamp = datetime.datetime.now().isoformat()
@@ -71,11 +75,26 @@ async def run_bpi():
             'responses_bpi',
             patient_id=patient_id,
             timestamp=timestamp,
-            question_number=i + 1,
+            question_number=qnum,
             question_text=question,
             response=response,
         )
+        qnum += 1
 
+        resp_lower = response.strip().lower()
+
+        # Conditional follow-ups
+        if index == 4 and resp_lower not in {"yes", "y"}:
+            index += 2  # skip 5b
+            continue
+        if index == 17 and resp_lower not in {"yes", "y"}:
+            index += 4  # skip 12a-c
+            continue
+        if index == 21 and resp_lower not in {"yes", "y"}:
+            index += 2  # skip question 14
+            continue
+
+        index += 1
 
     await robot_say(f"All responses saved for Patient ID: {patient_id}")
 

--- a/Dev/Filippo/MDD/oswestry_disability_index.py
+++ b/Dev/Filippo/MDD/oswestry_disability_index.py
@@ -38,7 +38,7 @@ DIGIT_WORDS = {
 
 # Questionnaire structure
 questions = [
-    ("PAIN INTENSITY", [
+    ("Which statement best describes your current pain intensity?", [
         "I can tolerate the pain I have without having to use pain killers",
         "The pain is bad but I manage without taking pain killers",
         "Pain killers give complete relief from pain",
@@ -46,7 +46,7 @@ questions = [
         "Pain killers give very little relief from pain",
         "Pain killers have no effect on the pain and I do not use them"
     ]),
-    ("PERSONAL CARE", [
+    ("Which option best reflects how pain affects your personal care?", [
         "I can look after myself normally without causing extra pain",
         "I can look after myself normally but it causes extra pain",
         "It is painful to look after myself and I am slow and careful",
@@ -54,7 +54,7 @@ questions = [
         "I need help every day in most aspects of self care",
         "I don’t get dressed, I wash with difficulty and stay in bed"
     ]),
-    ("LIFTING", [
+    ("Which statement best reflects your ability to lift items?", [
         "I can lift heavy weights without extra pain",
         "I can lift heavy weights but it gives extra pain",
         "Pain prevents me from lifting heavy weights off the floor, but I can manage if they are on a table",
@@ -62,7 +62,7 @@ questions = [
         "I can lift very light weights",
         "I cannot lift or carry anything at all"
     ]),
-    ("WALKING", [
+    ("Which statement best describes your walking ability?", [
         "Pain does not prevent me walking any distance",
         "Pain prevents me walking more than one mile",
         "Pain prevents me walking more than ½ mile",
@@ -70,7 +70,7 @@ questions = [
         "I can only walk using a stick or crutches",
         "I am in bed most of the time and have to crawl to the toilet"
     ]),
-    ("SITTING", [
+    ("Which statement best describes your ability to sit?", [
         "I can sit in any chair as long as I like",
         "I can only sit in my favorite chair as long as I like",
         "Pain prevents me from sitting more than one hour",
@@ -78,7 +78,7 @@ questions = [
         "Pain prevents me from sitting more than 10 minutes",
         "Pain prevents me from sitting at all"
     ]),
-    ("STANDING", [
+    ("Which statement best describes how long you can stand?", [
         "I can stand as long as I want without extra pain",
         "I can stand as long as I want but it gives me extra pain",
         "Pain prevents me from standing for more than one hour",
@@ -86,7 +86,7 @@ questions = [
         "Pain prevents me from standing for more than 10 minutes",
         "Pain prevents me from standing at all"
     ]),
-    ("SLEEPING", [
+    ("Which statement best describes how pain affects your sleep?", [
         "Pain does not prevent me from sleeping well",
         "I can sleep well only by using medication",
         "Even when I take medication, I have less than 6 hrs sleep",
@@ -94,7 +94,7 @@ questions = [
         "Even when I take medication, I have less than 2 hrs sleep",
         "Pain prevents me from sleeping at all"
     ]),
-    ("SOCIAL LIFE", [
+    ("Which statement best describes how pain affects your social life?", [
         "My social life is normal and gives me no extra pain",
         "My social life is normal but increases the degree of pain",
         "Pain has no significant effect apart from limiting energetic interests",
@@ -102,7 +102,7 @@ questions = [
         "Pain has restricted my social life to my home",
         "I have no social life because of pain"
     ]),
-    ("TRAVELLING", [
+    ("Which statement best describes how pain affects your travel?", [
         "I can travel anywhere without extra pain",
         "I can travel anywhere but it gives me extra pain",
         "Pain is bad, but I manage journeys over 2 hours",
@@ -110,7 +110,7 @@ questions = [
         "Pain restricts me to short necessary journeys under 30 minutes",
         "Pain prevents me from traveling except to the doctor or hospital"
     ]),
-    ("EMPLOYMENT / HOMEMAKING", [
+    ("Which statement best describes how pain affects your work or homemaking?", [
         "My normal job activities do not cause pain",
         "My normal job activities increase pain, but I can still perform all duties",
         "I can perform most duties, but pain prevents me from strenuous tasks",

--- a/Dev/Filippo/MDD/visualize_web.py
+++ b/Dev/Filippo/MDD/visualize_web.py
@@ -1,85 +1,9 @@
-"""Launch the patient results dashboard.
+"""Launch the patient results dashboard using the built-in web server.
 
-
-DB_NAME = "patient_responses.db"
-
-app = Flask(__name__)
-
-def get_available_tables(conn):
-    cur = conn.cursor()
-    cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
-    return [row[0] for row in cur.fetchall() if row[0].startswith('responses_')]
-
-def get_all_patient_ids(conn, tables):
-    """Return all unique patient IDs across response tables."""
-    cur = conn.cursor()
-    selects = [f"SELECT patient_id FROM {t}" for t in tables]
-    union = " UNION ".join(selects)
-    cur.execute(f"SELECT DISTINCT patient_id FROM ({union}) AS all_ids")
-    return [str(row[0]) for row in cur.fetchall() if row[0] is not None]
-
-def plot_data_for_table(patient_id, conn, table_name):
-    """Create a bar chart for the given patient from the specified table."""
-    cols = [row[1] for row in conn.execute(f"PRAGMA table_info({table_name})")]
-    if 'score' not in cols:
-        return None  # skip tables without numeric scores
-
-    q_col = None
-    for possible in ('question_title', 'question_text', 'dimension'):
-        if possible in cols:
-            q_col = possible
-            break
-    if q_col is None:
-        return None
-
-    cur = conn.cursor()
-    cur.execute(
-        f"SELECT {q_col}, score FROM {table_name} WHERE patient_id = ?",
-        (patient_id,),
-    )
-    rows = cur.fetchall()
-
-    fig, ax = plt.subplots(figsize=(9, 5))
-    if not rows:
-        ax.text(0.5, 0.5, f'No data found for {table_name}', ha='center', va='center')
-        ax.axis('off')
-    else:
-        labels = [str(r[0])[:40] for r in rows]
-        scores = [r[1] for r in rows]
-        ax.bar(labels, scores, color='#0d6efd')
-        ax.set_title(table_name.replace('responses_', '').upper())
-        ax.set_ylabel('Score')
-        ax.tick_params(axis='x', labelrotation=90)
-        ax.grid(True, axis='y', linestyle='--', alpha=0.7)
-
-    plt.tight_layout()
-    buf = io.BytesIO()
-    fig.savefig(buf, format='png')
-    plt.close(fig)
-    return base64.b64encode(buf.getvalue()).decode('utf-8')
-
-
-INDEX_TPL = """
-<!doctype html>
-<html lang=\"en\">
-<head>
-    <meta charset=\"utf-8\">
-    <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
-    <title>Patient Dashboard</title>
-</head>
-<body class=\"bg-light\">
-<div class="container py-4">
-  <h1 class="mb-4">Patient Dashboard</h1>
-  <ul class="list-group">
-    {% for pid in patient_ids %}
-      <li class="list-group-item"><a href="/patient/{{ pid }}">{{ pid }}</a></li>
-    {% endfor %}
-  </ul>
-</div>
-
-</body>
-</html>
-
+This module only exposes the :func:`run` function from ``web_dashboard`` so
+existing scripts can ``import visualize_web`` without needing Flask or
+Matplotlib.  The dashboard uses plain HTML and JavaScript and works in the
+Tritium environment.
 """
 
 from .web_dashboard import run


### PR DESCRIPTION
## Summary
- adjust `_LocalSystem.import_library` to resolve paths relative to caller and add `try_import_library`
- replace `visualize_web.py` with a lightweight wrapper around `web_dashboard`

## Testing
- `python -m py_compile Dev/Filippo/MDD/bpi_inventory.py Dev/Filippo/MDD/BeckDepression.py Dev/Filippo/MDD/oswestry_disability_index.py Dev/Filippo/MDD/remote_storage.py Dev/Filippo/MDD/main.py Dev/Filippo/MDD/visualize_web.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861da2ad17c832795a3fd5c0caf05ff