### PR TITLE
Fix input EOF crash in MDD speech utils

### DIFF
--- a/Dev/Filippo/MDD/speech_utils.py
+++ b/Dev/Filippo/MDD/speech_utils.py
@@ -22,7 +22,14 @@ async def robot_listen() -> str:
     if world is None:
 
         while True:
-            text = input("> ").strip()
+            try:
+                text = input("> ")
+            except EOFError:
+                # In non-interactive environments input() can raise EOFError.
+                # Returning an empty string allows the caller to handle the
+                # missing input gracefully instead of crashing.
+                return ""
+            text = text.strip()
             if text:
                 return text
             print("[Ameca]: I didn't catch that, please repeat.")


### PR DESCRIPTION
## Summary
- catch `EOFError` in `robot_listen` so the program does not crash if no stdin is present

## Testing
- `git ls-files '*.py' -z | xargs -0 python3 -m py_compile && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68620dc5b22c8327bd96f7324453c346