### PR TITLE
Simplify import handling

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -13,6 +13,7 @@ except NameError:  # pragma: no cover - executed locally
 
 if system is None:
     import importlib.util
+    import inspect
 
     class _LocalSystem:
         """Minimal stand-in for the robot system when running locally."""
@@ -20,12 +21,6 @@ if system is None:
         @staticmethod
         def import_library(rel_path: str):
             """Import a module relative to the caller's file."""
-            import inspect
-
-            # ``inspect.currentframe`` may return ``None`` in some execution
-            # environments (e.g. optimized or embedded interpreters). Using
-            # ``inspect.stack`` provides a more robust way to locate the caller
-            # frame across different runtime configurations.
             stack = inspect.stack()
             caller_path = None
             if len(stack) > 1:
@@ -53,13 +48,18 @@ if system is None:
                 return None
 
     system = _LocalSystem()
-    import builtins
-    builtins.system = system
+    import builtins as _builtins
+    _builtins.system = system
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 if MODULE_DIR not in sys.path:
     sys.path.append(MODULE_DIR)
+
+ACTION_UTIL = system.import_library("../../../HB3/chat/actions/action_util.py")
+ActionBuilder = ACTION_UTIL.ActionBuilder
+ActionRegistry = ACTION_UTIL.ActionRegistry
+Action = ACTION_UTIL.Action
 
 from remote_storage import send_to_server
 from speech_utils import robot_say, robot_listen

--- a/Dev/Filippo/MDD/speech_utils.py
+++ b/Dev/Filippo/MDD/speech_utils.py
@@ -22,7 +22,14 @@ async def robot_listen() -> str:
     if world is None:
 
         while True:
-            text = input("> ").strip()
+            try:
+                text = input("> ")
+            except EOFError:
+                # In non-interactive environments input() can raise EOFError.
+                # Returning an empty string allows the caller to handle the
+                # missing input gracefully instead of crashing.
+                return ""
+            text = text.strip()
             if text:
                 return text
             print("[Ameca]: I didn't catch that, please repeat.")


### PR DESCRIPTION
## Summary
- provide minimal fallback `system` with `import_library` for local runs
- use `system.import_library` to load action utilities
- remove custom `RunPainMoodAssessment` ActionBuilder

## Testing
- `git ls-files '*.py' -z | xargs -0 python3 -m py_compile && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68620dc5b22c8327bd96f7324453c346