### PR TITLE
Fix NameError in MDD main.py

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -48,15 +48,6 @@ if MODULE_DIR not in sys.path:
     sys.path.append(MODULE_DIR)
 
 ACTION_UTIL = system.import_library("../../../HB3/chat/actions/action_util.py")
-
-ACTION_UTIL = system.import_library("../../../HB3/chat/actions/action_util.py")
-ActionBuilder = ACTION_UTIL.ActionBuilder
-ActionRegistry = ACTION_UTIL.ActionRegistry
-Action = ACTION_UTIL.Action
-
-
-ACTION_UTIL = import_library("../../../HB3/chat/actions/action_util.py")
-
 ActionBuilder = ACTION_UTIL.ActionBuilder
 ActionRegistry = ACTION_UTIL.ActionRegistry
 Action = ACTION_UTIL.Action


### PR DESCRIPTION
## Summary
- remove duplicated imports
- use `system.import_library` directly to avoid NameError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68625826e2dc8327b69d2efff62b2e4d