### PR TITLE
Refactor Filippo MDD modules

### DIFF
--- a/Dev/Filippo/MDD/BeckDepression.py
+++ b/Dev/Filippo/MDD/BeckDepression.py
@@ -5,16 +5,36 @@ import datetime
 import asyncio
 import uuid
 import os
-import sys
 
 try:
-    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-except NameError:
-    MODULE_DIR = os.getcwd()
-if MODULE_DIR not in sys.path:
-    sys.path.append(MODULE_DIR)
-from remote_storage import send_to_server
-from speech_utils import robot_say, robot_listen
+    system  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - executed locally
+    import builtins
+    import importlib.util
+    import inspect
+
+    def _import_library(rel_path: str):
+        caller = inspect.stack()[1].filename
+        base_dir = os.path.dirname(os.path.abspath(caller))
+        abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
+        module_name = os.path.splitext(os.path.basename(rel_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, abs_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load module from {abs_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    class _LocalSystem:
+        import_library = staticmethod(_import_library)
+
+    system = _LocalSystem()
+    builtins.system = system
+
+send_to_server = system.import_library("./remote_storage.py").send_to_server
+speech_mod = system.import_library("./speech_utils.py")
+robot_say = speech_mod.robot_say
+robot_listen = speech_mod.robot_listen
 
 # Generate patient ID, preferring environment variable
 def get_patient_id() -> str:

--- a/Dev/Filippo/MDD/assessment_actions.py
+++ b/Dev/Filippo/MDD/assessment_actions.py
@@ -1,0 +1,20 @@
+from typing import List
+
+ACTION_UTIL = system.import_library("../../../HB3/chat/actions/action_util.py")
+ActionRegistry = ACTION_UTIL.ActionRegistry
+ActionBuilder = ACTION_UTIL.ActionBuilder
+Action = ACTION_UTIL.Action
+
+mdd_main = system.import_library("./main.py")
+
+
+@ActionRegistry.register_builder
+class RunMDDAssessment(ActionBuilder):
+    """Action to run the full MDD assessment workflow."""
+
+    def factory(self) -> List[Action]:
+        async def run_full_assessment() -> str:
+            await mdd_main.main()
+            return "mdd_assessment_finished"
+
+        return [run_full_assessment]

--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -5,17 +5,37 @@
 import asyncio
 import datetime
 import os
-import sys
 import uuid
 
 try:
-    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-except NameError:
-    MODULE_DIR = os.getcwd()
-if MODULE_DIR not in sys.path:
-    sys.path.append(MODULE_DIR)
-from remote_storage import send_to_server
-from speech_utils import robot_say, robot_listen
+    system  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - executed locally
+    import builtins
+    import importlib.util
+    import inspect
+
+    def _import_library(rel_path: str):
+        caller = inspect.stack()[1].filename
+        base_dir = os.path.dirname(os.path.abspath(caller))
+        abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
+        module_name = os.path.splitext(os.path.basename(rel_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, abs_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load module from {abs_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    class _LocalSystem:
+        import_library = staticmethod(_import_library)
+
+    system = _LocalSystem()
+    builtins.system = system
+
+send_to_server = system.import_library("./remote_storage.py").send_to_server
+speech_mod = system.import_library("./speech_utils.py")
+robot_say = speech_mod.robot_say
+robot_listen = speech_mod.robot_listen
 
 
 def get_patient_id() -> str:

--- a/Dev/Filippo/MDD/central_sensitization.py
+++ b/Dev/Filippo/MDD/central_sensitization.py
@@ -3,17 +3,37 @@
 import asyncio
 import datetime
 import os
-import sys
 import uuid
 
 try:
-    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-except NameError:
-    MODULE_DIR = os.getcwd()
-if MODULE_DIR not in sys.path:
-    sys.path.append(MODULE_DIR)
-from remote_storage import send_to_server
-from speech_utils import robot_say, robot_listen
+    system  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - executed locally
+    import builtins
+    import importlib.util
+    import inspect
+
+    def _import_library(rel_path: str):
+        caller = inspect.stack()[1].filename
+        base_dir = os.path.dirname(os.path.abspath(caller))
+        abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
+        module_name = os.path.splitext(os.path.basename(rel_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, abs_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load module from {abs_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    class _LocalSystem:
+        import_library = staticmethod(_import_library)
+
+    system = _LocalSystem()
+    builtins.system = system
+
+send_to_server = system.import_library("./remote_storage.py").send_to_server
+speech_mod = system.import_library("./speech_utils.py")
+robot_say = speech_mod.robot_say
+robot_listen = speech_mod.robot_listen
 
 
 

--- a/Dev/Filippo/MDD/dass21_assessment.py
+++ b/Dev/Filippo/MDD/dass21_assessment.py
@@ -3,17 +3,37 @@
 import asyncio
 import datetime
 import os
-import sys
 import uuid
 
 try:
-    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-except NameError:
-    MODULE_DIR = os.getcwd()
-if MODULE_DIR not in sys.path:
-    sys.path.append(MODULE_DIR)
-from remote_storage import send_to_server
-from speech_utils import robot_say, robot_listen
+    system  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - executed locally
+    import builtins
+    import importlib.util
+    import inspect
+
+    def _import_library(rel_path: str):
+        caller = inspect.stack()[1].filename
+        base_dir = os.path.dirname(os.path.abspath(caller))
+        abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
+        module_name = os.path.splitext(os.path.basename(rel_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, abs_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load module from {abs_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    class _LocalSystem:
+        import_library = staticmethod(_import_library)
+
+    system = _LocalSystem()
+    builtins.system = system
+
+send_to_server = system.import_library("./remote_storage.py").send_to_server
+speech_mod = system.import_library("./speech_utils.py")
+robot_say = speech_mod.robot_say
+robot_listen = speech_mod.robot_listen
 
 
 

--- a/Dev/Filippo/MDD/eq5d5l_assessment.py
+++ b/Dev/Filippo/MDD/eq5d5l_assessment.py
@@ -1,17 +1,37 @@
 import asyncio
 import datetime
 import os
-import sys
 import uuid
 
 try:
-    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-except NameError:
-    MODULE_DIR = os.getcwd()
-if MODULE_DIR not in sys.path:
-    sys.path.append(MODULE_DIR)
-from remote_storage import send_to_server
-from speech_utils import robot_say, robot_listen
+    system  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - executed locally
+    import builtins
+    import importlib.util
+    import inspect
+
+    def _import_library(rel_path: str):
+        caller = inspect.stack()[1].filename
+        base_dir = os.path.dirname(os.path.abspath(caller))
+        abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
+        module_name = os.path.splitext(os.path.basename(rel_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, abs_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load module from {abs_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    class _LocalSystem:
+        import_library = staticmethod(_import_library)
+
+    system = _LocalSystem()
+    builtins.system = system
+
+send_to_server = system.import_library("./remote_storage.py").send_to_server
+speech_mod = system.import_library("./speech_utils.py")
+robot_say = speech_mod.robot_say
+robot_listen = speech_mod.robot_listen
 
 # EQ-5D-5L dimension descriptions
 eq5d5l_dimensions = {

--- a/Dev/Filippo/MDD/oswestry_disability_index.py
+++ b/Dev/Filippo/MDD/oswestry_disability_index.py
@@ -1,17 +1,37 @@
 
 import os
-import sys
-
-try:
-    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-except NameError:
-    MODULE_DIR = os.getcwd()
-if MODULE_DIR not in sys.path:
-    sys.path.append(MODULE_DIR)
-from remote_storage import send_to_server
-from speech_utils import robot_say, robot_listen
 import uuid
 import datetime
+
+try:
+    system  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - executed locally
+    import builtins
+    import importlib.util
+    import inspect
+
+    def _import_library(rel_path: str):
+        caller = inspect.stack()[1].filename
+        base_dir = os.path.dirname(os.path.abspath(caller))
+        abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
+        module_name = os.path.splitext(os.path.basename(rel_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, abs_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load module from {abs_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    class _LocalSystem:
+        import_library = staticmethod(_import_library)
+
+    system = _LocalSystem()
+    builtins.system = system
+
+send_to_server = system.import_library("./remote_storage.py").send_to_server
+speech_mod = system.import_library("./speech_utils.py")
+robot_say = speech_mod.robot_say
+robot_listen = speech_mod.robot_listen
 
 
 

--- a/Dev/Filippo/MDD/pittsburgh_sleep.py
+++ b/Dev/Filippo/MDD/pittsburgh_sleep.py
@@ -3,18 +3,38 @@
 import asyncio
 import datetime
 import os
-import sys
 import uuid
 from typing import Literal
 
 try:
-    MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-except NameError:
-    MODULE_DIR = os.getcwd()
-if MODULE_DIR not in sys.path:
-    sys.path.append(MODULE_DIR)
-from remote_storage import send_to_server
-from speech_utils import robot_say, robot_listen
+    system  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - executed locally
+    import builtins
+    import importlib.util
+    import inspect
+
+    def _import_library(rel_path: str):
+        caller = inspect.stack()[1].filename
+        base_dir = os.path.dirname(os.path.abspath(caller))
+        abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
+        module_name = os.path.splitext(os.path.basename(rel_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, abs_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load module from {abs_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    class _LocalSystem:
+        import_library = staticmethod(_import_library)
+
+    system = _LocalSystem()
+    builtins.system = system
+
+send_to_server = system.import_library("./remote_storage.py").send_to_server
+speech_mod = system.import_library("./speech_utils.py")
+robot_say = speech_mod.robot_say
+robot_listen = speech_mod.robot_listen
 
 
 


### PR DESCRIPTION
## Summary
- cleanup imports in questionnaire modules
- add builder `RunMDDAssessment` to expose the full workflow as a chat action
- modernize `main.py` imports and add system fallback

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68625f666fc08327a83da010e6af0f81