### PR TITLE
Integrate assessments with robot response

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -237,9 +237,28 @@ async def main():
 
 class Activity:
 
-    async def on_start(self):
-        await main()
-        self.stop()
+    def on_start(self):
+        """Launch the assessment workflow as a robot response task."""
+        robot_state = system.import_library("../../../HB3/robot_state.py").state
+        self._task = robot_state.start_response_task(main())
+
+    def on_stop(self):
+        """Cancel any running questionnaire task."""
+        task = getattr(self, "_task", None)
+        if task and not task.done():
+            task.cancel()
+
+    def on_pause(self):
+        pass
+
+    def on_resume(self):
+        pass
+
+    @system.tick(fps=10)
+    def on_tick(self):
+        task = getattr(self, "_task", None)
+        if task and task.done():
+            self.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use robot response task to launch assessments
- manage cancellation on script stop
- add placeholder lifecycle hooks and periodic completion check

## Testing
- `python -m py_compile Dev/Filippo/MDD/main.py`
- `python -m compileall Dev/Filippo/MDD`

------
https://chatgpt.com/codex/tasks/task_e_68626773bf2c83279965a0cedfcad551