### PR TITLE
Allow running questionnaires locally

### DIFF
--- a/Dev/Filippo/MDD/BeckDepression.py
+++ b/Dev/Filippo/MDD/BeckDepression.py
@@ -28,6 +28,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 

--- a/Dev/Filippo/MDD/bpi_inventory.py
+++ b/Dev/Filippo/MDD/bpi_inventory.py
@@ -29,6 +29,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 

--- a/Dev/Filippo/MDD/central_sensitization.py
+++ b/Dev/Filippo/MDD/central_sensitization.py
@@ -27,6 +27,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 

--- a/Dev/Filippo/MDD/dass21_assessment.py
+++ b/Dev/Filippo/MDD/dass21_assessment.py
@@ -27,6 +27,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 

--- a/Dev/Filippo/MDD/eq5d5l_assessment.py
+++ b/Dev/Filippo/MDD/eq5d5l_assessment.py
@@ -25,6 +25,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 

--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -28,6 +28,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 

--- a/Dev/Filippo/MDD/oswestry_disability_index.py
+++ b/Dev/Filippo/MDD/oswestry_disability_index.py
@@ -25,6 +25,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 

--- a/Dev/Filippo/MDD/pain_catastrophizing.py
+++ b/Dev/Filippo/MDD/pain_catastrophizing.py
@@ -28,6 +28,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 

--- a/Dev/Filippo/MDD/pittsburgh_sleep.py
+++ b/Dev/Filippo/MDD/pittsburgh_sleep.py
@@ -28,6 +28,13 @@ except NameError:  # pragma: no cover - executed locally
     class _LocalSystem:
         import_library = staticmethod(_import_library)
 
+        @staticmethod
+        def tick(*, fps: int = 10):
+            """Return a decorator that simply returns the function."""
+            def decorator(func):
+                return func
+            return decorator
+
     system = _LocalSystem()
     builtins.system = system
 


### PR DESCRIPTION
## Summary
- add tick decorator stubs for local `_LocalSystem` classes

## Testing
- `python Dev/Filippo/MDD/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68626de067d48327a2307dfa75830a3e