### PR TITLE
Improve speech handling in assessments

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -70,9 +70,12 @@ oswestry_disability_index = system.import_library("./oswestry_disability_index.p
 pain_catastrophizing = system.import_library("./pain_catastrophizing.py")
 pittsburgh_sleep = system.import_library("./pittsburgh_sleep.py")
 
+# Disable language model rephrasing unless explicitly requested
+USE_LLM = os.environ.get("USE_LLM", "0") not in {"0", "false", "no"}
+
 async def say_with_llm(text: str) -> None:
     """Speak text, optionally expanded through the LLM."""
-    if llm is not None:
+    if USE_LLM and llm is not None:
         try:
             messages = [
                 {"role": "system", "content": "You are Ameca, an empathetic healthcare assistant."},
@@ -84,6 +87,7 @@ async def say_with_llm(text: str) -> None:
         except Exception:
             pass
     await robot_say(text)
+
 
 async def ask(question: str, key: str, store: dict, *, numeric: bool = False) -> str:
     """Ask a question and record the user's spoken answer."""

--- a/Dev/Filippo/MDD/speech_utils.py
+++ b/Dev/Filippo/MDD/speech_utils.py
@@ -66,7 +66,7 @@ async def robot_say(text: str) -> None:
             return
         except Exception:
             print("[WARN] Failed to use TTS client")
-    elif _tts_engine is not None:
+    if _tts_engine is not None:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, lambda: (_tts_engine.say(text), _tts_engine.runAndWait()))
         return

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ answer options are spoken aloud with text-to-speech and replies are captured
 from the `speech_recognized` event stream, so there is no console input during
 assessments.
 
+Set `USE_LLM=1` to let an external language model rephrase prompts before
+speaking them.  By default the exact questionnaire text is used.
+
 
 ## Patient identifiers
 


### PR DESCRIPTION
## Summary
- add `USE_LLM` variable to allow disabling rephrasing of prompts
- improve TTS fallback to use local engine when service call fails
- document `USE_LLM` in README

## Testing
- `find . -name '*.py' -type f -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_686378f878f08327a5eae536f8743aec