### PR TITLE
Improve speech handling in assessments

### DIFF
--- a/Dev/Filippo/MDD/speech_utils.py
+++ b/Dev/Filippo/MDD/speech_utils.py
@@ -62,11 +62,11 @@ async def robot_say(text: str) -> None:
         _tts_done.clear()
         try:
             _tts_client.send_api("say", text=text, voice="Amy", engine="Service Proxy")
-            await asyncio.wait_for(_tts_done.wait(), timeout=10)
+            await asyncio.wait_for(_tts_done.wait(), timeout=3)
             return
         except Exception:
             print("[WARN] Failed to use TTS client")
-    elif _tts_engine is not None:
+    if _tts_engine is not None:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, lambda: (_tts_engine.say(text), _tts_engine.runAndWait()))
         return

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ answer options are spoken aloud with text-to-speech and replies are captured
 from the `speech_recognized` event stream, so there is no console input during
 assessments.
 
+Set `USE_LLM=1` to let an external language model rephrase prompts before
+speaking them.  By default the exact questionnaire text is used.
+
+Each questionnaire is optional: before starting one you will be asked whether
+to proceed.  Answer "yes" to run it or "no" to skip all remaining
+questionnaires.
+
 
 ## Patient identifiers
 


### PR DESCRIPTION
## Summary
- add `USE_LLM` variable to allow disabling rephrasing of prompts
- improve TTS fallback to use local engine when service call fails
- prompt before each questionnaire, stopping if patient declines
- document questionnaire opt-in and `USE_LLM`

## Testing
- `find . -name '*.py' -type f -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_686378f878f08327a5eae536f8743aec