### PR TITLE
Fix questionnaire stuck in silent mode

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -119,8 +119,6 @@ def store_demographics(pid: str, data: dict) -> None:
 
 async def collect_demographics() -> str | None:
     await say_with_llm("Welcome to the Pain & Mood Assessment System")
-    if system.messaging is not None:
-        system.messaging.post("mode_change", "silent")
     answers: dict[str, str] = {}
 
     last = await ask("Please tell me your last name", "name_last", answers)
@@ -140,6 +138,8 @@ async def collect_demographics() -> str | None:
         return None
 
     await robot_say("Thank you, let's continue.")
+    if system.messaging is not None:
+        system.messaging.post("mode_change", "silent")
 
     await ask("Middle initial if any", "name_middle", answers)
     await ask("Phone number", "phone", answers)

--- a/README.md
+++ b/README.md
@@ -55,24 +55,12 @@ from the `speech_recognized` event stream, so there is no console input during
 assessments.
 
 When running on the robot the script switches the chat system to "silent" mode
-after greeting the patient so that general conversation does not interrupt the
-questionnaires.  The previous mode is restored when the program finishes.
+only **after** the patient confirms they want to proceed. This prevents random
+conversation from interrupting the questionnaires. The previous mode is
+restored when the program finishes.
 
 Set `USE_LLM=1` to let an external language model rephrase prompts before
 speaking them.  By default the exact questionnaire text is used.
-
-Each questionnaire is optional: before starting one you will be asked whether
-to proceed.  Answer "yes" to run it or "no" to skip all remaining
-questionnaires.
-
-
-When running on the robot the script automatically switches the chat system to
-"silent" mode so that general conversation does not interrupt the
-questionnaires.  The previous mode is restored when the program finishes.
-
-Set `USE_LLM=1` to let an external language model rephrase prompts before
-speaking them.  By default the exact questionnaire text is used.
-
 
 Each questionnaire is optional: before starting one you will be asked whether
 to proceed.  Answer "yes" to run it or "no" to skip all remaining


### PR DESCRIPTION
## Summary
- avoid entering silent mode until the user agrees to continue
- document that silent mode is now enabled only after consent

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_6863871f7d7c8327a1d34741e81ff964