### PR TITLE
Add conversation history logging

### DIFF
--- a/Dev/Filippo/MDD/http_server.py
+++ b/Dev/Filippo/MDD/http_server.py
@@ -108,6 +108,13 @@ TABLE_SCHEMAS = {
             question_text TEXT,
             answer TEXT,
             score INTEGER
+        )''',
+    'conversation_history': '''
+        CREATE TABLE IF NOT EXISTS conversation_history (
+            timestamp TEXT,
+            speaker TEXT,
+            text TEXT,
+            id TEXT
         )'''
 }
 

--- a/HB3/Chat_Controller.py
+++ b/HB3/Chat_Controller.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+import datetime
 
 """
 System
@@ -39,6 +40,7 @@ CHAT_SYSTEM_TYPE = CONFIG["CHAT_SYSTEM_TYPE"]
 MODES_CONFIG_LIB = system.import_library("./modes_config.py")
 
 VOICE_ID_UTIL = system.import_library("./Perception/lib/voice_id_util.py")
+REMOTE_STORAGE = system.import_library("../Dev/Filippo/MDD/remote_storage.py")
 
 default_voice_reset_evt = system.event("default_voice_reset")
 
@@ -131,6 +133,16 @@ class Activity:
             ):
                 active_history.add_to_memory(event)
             log.info(f"{speaker if speaker else 'User'}: {message['text']}")
+            try:
+                REMOTE_STORAGE.send_to_server(
+                    "conversation_history",
+                    timestamp=datetime.datetime.now().isoformat(),
+                    speaker=speaker or "user",
+                    text=message["text"],
+                    id=message.get("id") or "",
+                )
+            except Exception:
+                pass
             is_interaction = True
 
         if channel == "non_verbal_interaction_trigger":

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ recorded:
 ```bash
 sqlite3 patient_responses.db ".tables"
 sqlite3 patient_responses.db "SELECT * FROM patient_demographics LIMIT 5;"
+sqlite3 patient_responses.db "SELECT * FROM conversation_history LIMIT 5;"
 ```
 
 


### PR DESCRIPTION
## Summary
- capture recognized speech events in `Chat_Controller` and send them to the HTTP backend
- extend the HTTP server with a `conversation_history` table
- document how to query the new table

## Testing
- `pytest -q`
- `python -m py_compile HB3/Chat_Controller.py Dev/Filippo/MDD/http_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6867aea03af48327bd69b76dc90517e9