### PR TITLE
Log conversation events and revert chat controller

### DIFF
--- a/Dev/Filippo/MDD/http_server.py
+++ b/Dev/Filippo/MDD/http_server.py
@@ -108,6 +108,13 @@ TABLE_SCHEMAS = {
             question_text TEXT,
             answer TEXT,
             score INTEGER
+        )''',
+    'conversation_history': '''
+        CREATE TABLE IF NOT EXISTS conversation_history (
+            timestamp TEXT,
+            speaker TEXT,
+            text TEXT,
+            id TEXT
         )'''
 }
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ recorded:
 ```bash
 sqlite3 patient_responses.db ".tables"
 sqlite3 patient_responses.db "SELECT * FROM patient_demographics LIMIT 5;"
+sqlite3 patient_responses.db "SELECT * FROM conversation_history LIMIT 5;"
 ```
 
 
@@ -57,7 +58,9 @@ assessments.
 
 When running on the robot the script no longer switches the chat system to
 "silent" mode. Questions are asked in normal conversation mode throughout the
-assessment so that answers are captured without interruption.
+assessment so that answers are captured without interruption.  The activity sets
+the environment variable `MDD_ASSESSMENT_ACTIVE=1` while running so other
+components can detect that a questionnaire session is in progress.
 
 After greeting the patient the program collects demographic details such as
 name, birth date and occupation. Once those questions are completed Ameca asks


### PR DESCRIPTION
## Summary
- revert Chat_Controller.py to previous version
- record all recognised speech in `conversation_history` via `main.py`
- clarify `MDD_ASSESSMENT_ACTIVE` explanation in README

## Testing
- `python -m py_compile HB3/Chat_Controller.py Dev/Filippo/MDD/main.py Dev/Filippo/MDD/http_server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867aea03af48327bd69b76dc90517e9