### PR TITLE
Patch chat controller at runtime

### DIFF
--- a/Dev/Filippo/MDD/http_server.py
+++ b/Dev/Filippo/MDD/http_server.py
@@ -108,6 +108,13 @@ TABLE_SCHEMAS = {
             question_text TEXT,
             answer TEXT,
             score INTEGER
+        )''',
+    'conversation_history': '''
+        CREATE TABLE IF NOT EXISTS conversation_history (
+            timestamp TEXT,
+            speaker TEXT,
+            text TEXT,
+            id TEXT
         )'''
 }
 


### PR DESCRIPTION
## Summary
- add runtime patch for Chat_Controller to skip LLM when the assessment is active and log speech locally
- call the new patch when the Activity starts

## Testing
- `python -m py_compile HB3/Chat_Controller.py Dev/Filippo/MDD/main.py Dev/Filippo/MDD/http_server.py HB3/chat/modes/llm_decider_mode.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867aea03af48327bd69b76dc90517e9