### PR TITLE
Fix questionnaire progression after speech recognition

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -86,10 +86,24 @@ def _patch_llm_decider_mode() -> None:
     llm_mod.LLMDeciderMode.on_message = patched_on_message
     llm_mod._mdd_patch_applied = True
 
-async def listen() -> str:
-    """Return the next recognized speech string from the queue or ASR."""
+async def listen(timeout: float | None = None) -> str:
+    """Return the next recognized speech string from the queue or ASR.
+
+    Parameters
+    ----------
+    timeout:
+        Maximum number of seconds to wait for recognised speech.  If the
+        timeout expires, an empty string is returned.  This prevents the
+        questionnaire from stalling indefinitely if no speech is detected.
+    """
+
     if system.messaging is not None:
-        return await speech_queue.get()
+        if timeout is None:
+            return await speech_queue.get()
+        try:
+            return await asyncio.wait_for(speech_queue.get(), timeout)
+        except asyncio.TimeoutError:
+            return ""
     return await robot_listen()
 
 
@@ -117,7 +131,13 @@ async def ask(question: str, key: str, store: dict, *, numeric: bool = False) ->
     """Ask a question and record the user's spoken answer."""
     await robot_say(question)
 
-    ans = await listen()
+    while not speech_queue.empty():
+        try:
+            speech_queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+
+    ans = await listen(timeout=10)
 
     await say_with_llm("Thank you.")
     if numeric:


### PR DESCRIPTION
## Summary
- add an optional timeout to `listen` so waiting for speech won't block forever
- flush old speech queue items before each question
- use the new timeout while waiting for answers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ba51fb0f88327bd44b0dc2f4fb583