### PR TITLE
Fix ask function speech

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -192,13 +192,11 @@ async def ask(question: str, key: str, store: dict, *, numeric: bool = False) ->
 
     await robot_say(question)
 
-
     ans = ""
     while not ans:
-        ans = (await wait_for_answer()).strip()
+        ans = (await robot_listen()).strip()
         if not ans:
             await robot_say("I didn't catch that, please repeat.")
-
 
     await say_with_llm("Thank you.")
     if numeric:


### PR DESCRIPTION
## Summary
- make the `ask` helper use `robot_listen` for answers instead of the speech queue

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb72c89c88327a82170d1228a1093