### PR TITLE
Fix last name prompt and shorten speech wait

### DIFF
--- a/Dev/Filippo/MDD/speech_utils.py
+++ b/Dev/Filippo/MDD/speech_utils.py
@@ -105,7 +105,7 @@ async def robot_say(text: str) -> None:
         _tts_done.clear()
         try:
             _tts_client.send_api("say", text=text, voice="Amy", engine="Service Proxy")
-            timeout = max(3.0, len(text) * 0.2)
+            timeout = min(max(2.0, len(text) * 0.07), 8.0)
             await asyncio.wait_for(_tts_done.wait(), timeout=timeout)
             return
         except Exception:


### PR DESCRIPTION
## Summary
- integrate last name question with initial welcome prompt
- trim speech wait time so next question plays faster

## Testing
- `python -m py_compile Dev/Filippo/MDD/main.py Dev/Filippo/MDD/speech_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_686bc299188c832795d47708583bac9c