### PR TITLE
Enhance conversation history storage

### DIFF
--- a/Dev/Filippo/MDD/http_server.py
+++ b/Dev/Filippo/MDD/http_server.py
@@ -114,6 +114,7 @@ TABLE_SCHEMAS = {
             timestamp TEXT,
             speaker TEXT,
             text TEXT,
+            patient_id TEXT,
             id TEXT
         )'''
 }

--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -381,6 +381,8 @@ async def main() -> None:
     assessment directly from the command line.
     """
     _patch_llm_decider_mode()
+    if "patient_id" not in os.environ:
+        os.environ["patient_id"] = f"PAT-{uuid.uuid4().hex[:8]}"
     os.environ["MDD_ASSESSMENT_ACTIVE"] = "1"
     await ensure_volume(50)
 

--- a/Dev/Filippo/MDD/remote_storage.py
+++ b/Dev/Filippo/MDD/remote_storage.py
@@ -46,6 +46,11 @@ def send_to_server(table: str, **data) -> None:
     If the server cannot be reached, the data is stored locally in
     ``patient_responses.db`` instead of emitting repeated warnings.
     """
+    if table == "conversation_history" and "patient_id" not in data:
+        pid = os.environ.get("patient_id")
+        if pid:
+            data["patient_id"] = pid
+
     payload = json.dumps({"table": table, **data}).encode("utf-8")
     if SERVER_URL:
         req = request.Request(

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ sqlite3 patient_responses.db "SELECT * FROM patient_demographics LIMIT 5;"
 sqlite3 patient_responses.db "SELECT * FROM conversation_history LIMIT 5;"
 ```
 
+The `conversation_history` table now stores a `patient_id` column so that each
+spoken utterance is linked to the active patient session.  Set the environment
+variable `patient_id` before running or allow the script to generate a random
+identifier automatically.
+
 
 The first command shows all tables created by the server.  You can then run
 standard SQLite queries to inspect the contents and confirm that data was saved.
@@ -85,6 +90,9 @@ already contains a record with the same first and last name, that existing ID is
 reused so repeated visits are linked to the correct patient.  To run any
 questionnaire independently you can set the environment variable `patient_id`
 before execution.
+
+This identifier is also used to tag entries in the `conversation_history` table
+so that spoken answers can be viewed per patient.
 
 To skip collection of demographic details entirely, set `AUTO_MODE=1` when
 running `main.py`.  In this mode a random patient ID is generated (unless


### PR DESCRIPTION
## Summary
- track patient_id in conversation_history table
- add automatic patient_id injection in `remote_storage.send_to_server`
- set a patient_id when launching the assessment so history is tagged from the start
- document the new behaviour in the README

## Testing
- `python -m py_compile Dev/Filippo/MDD/http_server.py Dev/Filippo/MDD/main.py Dev/Filippo/MDD/remote_storage.py`

------
https://chatgpt.com/codex/tasks/task_e_686c7eca4e308327b0f0a629ccd2a5be