### PR TITLE
Fix duplicate patient ID submission

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -214,7 +214,8 @@ async def ask(question: str, key: str, store: dict, *, numeric: bool = False) ->
     return ans
 
 def store_demographics(pid: str, data: dict) -> None:
-    remote_storage.send_to_server("patient_demographics", patient_id=pid, **data)
+    # `data` already contains the patient_id, avoid passing it twice
+    remote_storage.send_to_server("patient_demographics", **data)
 
 async def collect_demographics() -> str | None:
     answers: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- avoid passing the patient_id twice when storing demographics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c97e12a148327b2ff6051c74161e5