### PR TITLE
Fix demographic data storage

### DIFF
--- a/Dev/Filippo/MDD/main.py
+++ b/Dev/Filippo/MDD/main.py
@@ -214,7 +214,10 @@ async def ask(question: str, key: str, store: dict, *, numeric: bool = False) ->
     return ans
 
 def store_demographics(pid: str, data: dict) -> None:
-    remote_storage.send_to_server("patient_demographics", patient_id=pid, **data)
+    """Store demographics for ``pid`` ensuring the ID is included once."""
+    payload = dict(data)
+    payload["patient_id"] = pid
+    remote_storage.send_to_server("patient_demographics", **payload)
 
 async def collect_demographics() -> str | None:
     answers: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- ensure the patient ID is sent only once when storing demographic info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c97e12a148327b2ff6051c74161e5