### PR TITLE
Add Tritium sender for Ameca Live Link

### DIFF
--- a/Dev/Filippo/MDD/ameca_tritium_sender.py
+++ b/Dev/Filippo/MDD/ameca_tritium_sender.py
@@ -1,8 +1,8 @@
 """Send Ameca viseme and head pose data to Unreal Live Link.
 
 This module runs inside the Tritium environment and forwards mouth viseme
-weights, head orientation and blink events to the Live Link bridge running on
-an Unreal Engine machine.
+weights, **mouth openness**, head orientation and blink events to the Live Link
+bridge running on an Unreal Engine machine.
 
 Usage examples::
 
@@ -163,6 +163,11 @@ def run(hosts: Iterable[str], port: int) -> None:
                 phoneme = VISEME_MAP.get(name)
                 if phoneme:
                     send({"type": "viseme", "name": phoneme, "weight": float(weight)})
+
+        open_amt = getattr(mouth, "mouth_open", 0.0)
+        if open_amt > 0.01:
+            # Mouth driver exposes [0,2] range; Live Link expects [0,1]
+            send({"type": "viseme", "name": "Open", "weight": float(open_amt) / 2.0})
 
         if robot_state.blinking and not blink_state:
             send({"type": "gesture", "name": "blink"})

--- a/Dev/Filippo/MDD/ameca_tritium_sender.py
+++ b/Dev/Filippo/MDD/ameca_tritium_sender.py
@@ -1,0 +1,190 @@
+"""Send Ameca viseme and head pose data to Unreal Live Link.
+
+This module runs inside the Tritium environment and forwards mouth viseme
+weights, head orientation and blink events to the Live Link bridge running on
+an Unreal Engine machine.
+
+Usage examples::
+
+    # Stream to the bridge on a specific machine
+    python ameca_tritium_sender.py --host 10.63.3.105 --port 8210
+
+    # Try both loopback and the host's LAN address
+    python ameca_tritium_sender.py --host auto
+
+The bridge script (``ameca_livelink_bridge.py``) must be running on the
+specified host and port. In Unreal, select subject ``AmecaBridge`` in the Live
+Link panel for your MetaHuman avatar.
+"""
+
+try:
+    system  # type: ignore[name-defined]
+except NameError:  # pragma: no cover - executed locally
+    import builtins
+    import importlib.util
+    import inspect
+    import os
+
+    def _import_library(rel_path: str):
+        caller = inspect.stack()[1].filename
+        base_dir = os.path.dirname(os.path.abspath(caller))
+        abs_path = os.path.abspath(os.path.join(base_dir, rel_path))
+        module_name = os.path.splitext(os.path.basename(rel_path))[0]
+        spec = importlib.util.spec_from_file_location(module_name, abs_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load module from {abs_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    class _LocalSystem:
+        import_library = staticmethod(_import_library)
+
+        def control(self, *_, **__):  # pragma: no cover - placeholder
+            raise RuntimeError("system.control unavailable outside Tritium")
+
+        def tick(self, fps: int = 60):  # pragma: no cover - placeholder
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def run(self):  # pragma: no cover - placeholder
+            raise RuntimeError("system.run unavailable outside Tritium")
+
+        class unstable:  # pragma: no cover - placeholder
+            class owner:
+                mouth_driver = None
+
+    system = _LocalSystem()
+    builtins.system = system
+
+if not hasattr(system, "import_library"):
+    raise RuntimeError("system.import_library missing")
+
+import argparse
+import json
+import socket
+from typing import Dict, Iterable, List
+
+# Map Tritium viseme names to Live Link phoneme identifiers
+VISEME_MAP = {
+    "Viseme A": "AA",
+    "Viseme CH": "CH",
+    "Viseme Closed": "M",
+    "Viseme E": "EH",
+    "Viseme F": "F",
+    "Viseme I": "IY",
+    "Viseme ING": "NG",
+    "Viseme KK": "K",
+    "Viseme M": "M",
+    "Viseme NN": "N",
+    "Viseme O": "OW",
+    "Viseme RR": "ER",
+    "Viseme SS": "S",
+    "Viseme U": "UW",
+}
+
+robot_state = None
+head_yaw = head_pitch = head_roll = None
+
+
+def _resolve_hosts(host: str) -> List[str]:
+    """Return a list of destination IPs.
+
+    ``host`` may be a comma separated list. If the token ``"auto"`` is present,
+    the function expands it to include both the loopback address and the
+    primary LAN address of the machine running the script. This helps when the
+    exact Unreal Engine IP is unknown: one of the addresses will usually be
+    correct.
+    """
+
+    parts = [h.strip() for h in host.split(",") if h.strip()]
+    ips: List[str] = []
+
+    if "auto" in parts:
+        parts.remove("auto")
+        ips.append("127.0.0.1")
+        try:
+            hostname_ips = socket.gethostbyname_ex(socket.gethostname())[2]
+            for ip in hostname_ips:
+                if ip not in ips:
+                    ips.append(ip)
+        except socket.gaierror:
+            pass
+
+    ips.extend(parts)
+    return ips
+
+
+def run(hosts: Iterable[str], port: int) -> None:
+    """Start streaming head pose and viseme data to the bridge."""
+    global robot_state, head_yaw, head_pitch, head_roll
+
+    if robot_state is None:
+        robot_state = system.import_library("../../../HB3/robot_state.py").state
+
+    if head_yaw is None:
+        head_yaw = system.control("Head Yaw", "Mesmer Neck 1", acquire=["position"])
+        head_pitch = system.control("Head Pitch", "Mesmer Neck 1", acquire=["position"])
+        head_roll = system.control("Head Roll", "Mesmer Neck 1", acquire=["position"])
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    dests = [(h, port) for h in hosts]
+    print("Streaming to:", ", ".join(f"{h}:{port}" for h in hosts))
+
+    mouth = system.unstable.owner.mouth_driver
+    blink_state = False
+
+    def send(payload: Dict[str, float | str]) -> None:
+        data = json.dumps(payload).encode()
+        for dest in dests:
+            sock.sendto(data, dest)
+
+    @system.tick(fps=60)
+    def stream() -> None:
+        nonlocal mouth, blink_state
+        if mouth is None:
+            mouth = system.unstable.owner.mouth_driver
+            if mouth is None:
+                return
+
+        send(
+            {
+                "type": "pose",
+                "yaw": head_yaw.position or 0.0,
+                "pitch": head_pitch.position or 0.0,
+                "roll": head_roll.position or 0.0,
+            }
+        )
+
+        for name, weight in mouth.viseme_demands.items():
+            if weight > 0.01:
+                phoneme = VISEME_MAP.get(name)
+                if phoneme:
+                    send({"type": "viseme", "name": phoneme, "weight": float(weight)})
+
+        if robot_state.blinking and not blink_state:
+            send({"type": "gesture", "name": "blink"})
+        blink_state = robot_state.blinking
+
+    system.run()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Stream Ameca facial data to Unreal Live Link")
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help=(
+            "Destination IP of ameca_livelink_bridge. Accepts a comma-separated"
+            " list. Use 'auto' to send to both loopback and the machine's LAN IP"
+        ),
+    )
+    parser.add_argument("--port", type=int, default=8210, help="UDP port of the bridge")
+    args = parser.parse_args()
+    run(_resolve_hosts(args.host), args.port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Support comma-separated host list and document usage for directing Ameca data to specific machines
- Allow ameca_tritium_sender.py to run standalone by stubbing system when absent

## Testing
- `python -m py_compile Dev/Filippo/MDD/ameca_tritium_sender.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d5e340d848327af872fcbdbe96626