### PR TITLE
Add debug logging to Ameca Tritium sender

### DIFF
--- a/Dev/Filippo/MDD/ameca_tritium_sender.py
+++ b/Dev/Filippo/MDD/ameca_tritium_sender.py
@@ -32,8 +32,13 @@ import argparse
 import json
 import os
 
+import logging
 import socket
 from typing import Dict, Iterable, List
+
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 # Map Tritium viseme names to Live Link phoneme identifiers
 VISEME_MAP = {
@@ -55,6 +60,23 @@ VISEME_MAP = {
 
 robot_state = None
 head_yaw = head_pitch = head_roll = None
+mix_pose = None
+
+# Demand prefixes to forward as generic facial channels. The MixDemandHub
+# exposes a large set of values (brows, eyelids, nose, etc.) and the bridge
+# only needs the raw numeric value.  Each demand name that begins with one of
+# these prefixes will be forwarded to the Live Link bridge as an individual
+# channel.
+FACIAL_PREFIXES: tuple[str, ...] = (
+    "Brow",
+    "Eyelid",
+    "Eye",
+    "Gaze",
+    "Nose",
+    "Lip",
+    "Mouth",
+    "Jaw",
+)
 
 
 
@@ -68,6 +90,7 @@ def _resolve_hosts(host: str) -> List[str]:
     correct.
     """
 
+    logger.debug("Resolving host string %s", host)
     parts = [h.strip() for h in host.split(",") if h.strip()]
     ips: List[str] = []
 
@@ -76,13 +99,15 @@ def _resolve_hosts(host: str) -> List[str]:
         ips.append("127.0.0.1")
         try:
             hostname_ips = socket.gethostbyname_ex(socket.gethostname())[2]
+            logger.debug("Discovered host IPs: %s", hostname_ips)
             for ip in hostname_ips:
                 if ip not in ips:
                     ips.append(ip)
-        except socket.gaierror:
-            pass
+        except socket.gaierror as exc:
+            logger.warning("Failed to resolve local host IPs: %s", exc)
 
     ips.extend(parts)
+    logger.debug("Resolved hosts: %s", ips)
     return ips
 
 
@@ -103,57 +128,98 @@ def run(hosts: Iterable[str], port: int, *, block: bool = True) -> None:
         hanging the IDE.
     """
 
-    global robot_state, head_yaw, head_pitch, head_roll
+    global robot_state, head_yaw, head_pitch, head_roll, mix_pose
 
     if robot_state is None:
         try:
+            logger.debug("Importing robot_state module")
             robot_state = system.import_library("../../../HB3/robot_state.py").state
+            logger.debug("robot_state imported successfully")
         except Exception as exc:  # pragma: no cover - fails if run outside Tritium
+            logger.exception("Failed to import robot_state")
             raise RuntimeError("robot_state unavailable; run inside Tritium") from exc
 
 
     if head_yaw is None:
+        logger.debug("Acquiring head control interfaces")
         head_yaw = system.control("Head Yaw", "Mesmer Neck 1", acquire=["position"])
         head_pitch = system.control("Head Pitch", "Mesmer Neck 1", acquire=["position"])
         head_roll = system.control("Head Roll", "Mesmer Neck 1", acquire=["position"])
 
+    if mix_pose is None:
+        mix_pose = getattr(system.unstable.owner, "mix_pose", None)
+        logger.debug("Initial mix_pose hub: %s", mix_pose)
+
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     dests = [(h, port) for h in hosts]
-    print("Streaming to:", ", ".join(f"{h}:{port}" for h in hosts))
+    logger.info("Streaming to: %s", ", ".join(f"{h}:{port}" for h in hosts))
     if all(h.startswith("127.") for h in hosts):
-        print(
-            "WARNING: only streaming to loopback. If Unreal runs on another machine,"
-            " supply its IP with --host"
+        logger.warning(
+            "Only streaming to loopback. If Unreal runs on another machine, supply its IP with --host"
         )
 
 
     mouth = system.unstable.owner.mouth_driver
     blink_state = False
+    speech_state = False
+    logger.debug("Initial mouth driver: %s", mouth)
 
     def send(payload: Dict[str, float | str]) -> None:
         data = json.dumps(payload).encode()
         for dest in dests:
-            sock.sendto(data, dest)
+            try:
+                logger.debug("Sending %s to %s", payload, dest)
+                sock.sendto(data, dest)
+            except OSError as exc:
+                logger.exception("Failed to send data to %s: %s", dest, exc)
 
 
     @system.tick(fps=60)
     def stream() -> None:
-        nonlocal mouth, blink_state
+        nonlocal mouth, blink_state, speech_state
+        global mix_pose
         if mouth is None:
+            logger.debug("Mouth driver not set; attempting to reacquire")
             mouth = system.unstable.owner.mouth_driver
+            logger.debug("Reacquired mouth driver: %s", mouth)
             if mouth is None:
+                logger.debug("Mouth driver still unavailable; skipping tick")
                 return
 
-        send(
-            {
-                "type": "pose",
-                "yaw": head_yaw.position or 0.0,
-                "pitch": head_pitch.position or 0.0,
-                "roll": head_roll.position or 0.0,
-            }
-        )
+        head_vals: Dict[tuple[str, str], float] = {}
+        current_mix = mix_pose or getattr(system.unstable.owner, "mix_pose", None)
+        if current_mix is not None:
+            if mix_pose is None:
+                mix_pose = current_mix
+                logger.debug("Reacquired mix_pose hub: %s", mix_pose)
+            try:
+                head_vals = current_mix.get_values()
+                logger.debug(
+                    "mix_pose head/neck values: %s",
+                    {str(k): v for k, v in head_vals.items() if "Head" in k[0] or "Neck" in k[0]},
+                )
+            except Exception as exc:  # pragma: no cover - mix_pose may not be initialised
+                logger.exception("Failed to read mix_pose values: %s", exc)
+
+        yaw = head_vals.get(("Head Yaw", "Mesmer Neck 1"), head_yaw.position or 0.0)
+        pitch = head_vals.get(("Head Pitch", "Mesmer Neck 1"), head_pitch.position or 0.0)
+        pitch += head_vals.get(("Neck Pitch", "Mesmer Neck 1"), 0.0)
+        roll = head_vals.get(("Head Roll", "Mesmer Neck 1"), head_roll.position or 0.0)
+        roll += head_vals.get(("Neck Roll", "Mesmer Neck 1"), 0.0)
+
+        pose_payload = {"type": "pose", "yaw": yaw, "pitch": pitch, "roll": roll}
+        logger.debug("Pose payload: %s", pose_payload)
+        send(pose_payload)
+
+        # Forward all other MixDemandHub facial channels so the avatar can mirror
+        # nose, brow, eyelid and gaze motion.  The demand name itself is sent as
+        # the channel identifier; downstream consumers can remap as needed.
+        for (demand, _board), value in head_vals.items():
+            if any(demand.startswith(prefix) for prefix in FACIAL_PREFIXES):
+                send({"type": "blendshape", "name": demand, "value": float(value)})
 
         for name, weight in mouth.viseme_demands.items():
+            logger.debug("Viseme %s weight %s", name, weight)
             if weight > 0.01:
                 phoneme = VISEME_MAP.get(name)
                 if phoneme:
@@ -163,19 +229,28 @@ def run(hosts: Iterable[str], port: int, *, block: bool = True) -> None:
         if callable(open_amt):  # ``mouth_open`` may be a @parameter partial
             try:
                 open_amt = open_amt()
-            except Exception:
+            except Exception as exc:
+                logger.exception("Failed to read mouth_open: %s", exc)
                 open_amt = 0.0
 
+        logger.debug("Mouth open amount: %s", open_amt)
         if open_amt > 0.01:
             # Mouth driver exposes [0,2] range; Live Link expects [0,1]
             send({"type": "viseme", "name": "Open", "weight": float(open_amt) / 2.0})
 
 
         if robot_state.blinking and not blink_state:
+            logger.debug("Blink detected")
             send({"type": "gesture", "name": "blink"})
         blink_state = robot_state.blinking
+        logger.debug("Blink state: %s", blink_state)
+
+        if robot_state.speaking != speech_state:
+            send({"type": "speech", "speaking": bool(robot_state.speaking)})
+            speech_state = robot_state.speaking
 
     if block:
+        logger.debug("Blocking execution; entering runtime loop")
         run_fn = getattr(system, "run", None)
         if callable(run_fn):
             run_fn()
@@ -186,6 +261,7 @@ def run(hosts: Iterable[str], port: int, *, block: bool = True) -> None:
                 while True:
                     time.sleep(3600)
             except KeyboardInterrupt:
+                logger.debug("Interrupted by user")
                 pass
 
 
@@ -199,9 +275,11 @@ class Activity:
         env_port = int(os.environ.get("LIVE_LINK_PORT", "8210"))
         self.host = host or env_host
         self.port = port or env_port
+        logger.debug("Activity created with host=%s port=%s", self.host, self.port)
 
 
     def on_start(self) -> None:
+        logger.debug("Activity starting")
         run(_resolve_hosts(self.host), self.port, block=False)
 
 
@@ -225,6 +303,7 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+    logger.debug("Parsed arguments: host=%s port=%s", args.host, args.port)
     run(_resolve_hosts(args.host), args.port)
 
 


### PR DESCRIPTION
## Summary
- read head and neck pose from mix_pose demand hub to capture animation-driven motion
- include combined neck pitch/roll values in head pose payload
- maintain debug logging for mix_pose values and reacquisition

## Testing
- `python -m py_compile Dev/Filippo/MDD/ameca_tritium_sender.py`
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_689d8b48a5248327b081cb387b958f9c